### PR TITLE
new data types for ndarray constructor

### DIFF
--- a/Makefile.frag
+++ b/Makefile.frag
@@ -80,6 +80,7 @@ install-cuda:
 	$(CC)    -I. $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(CC_ARCH_FLAGS) $(EXTRA_CFLAGS)  $(ALL_CCFLAGS) $(GENCODE_FLAGS)  -c $(builddir)./src/ndarray/frontend/manipulations.c -shared -fPIC -o .libs/ndarray__frontend__manipulations.o
 	$(CC)    -I. $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(CC_ARCH_FLAGS) $(EXTRA_CFLAGS)  $(ALL_CCFLAGS) $(GENCODE_FLAGS)  -c $(builddir)./src/ndarray.c -shared -fPIC -o .libs/ndarray.o
 	$(NVCC)  -I. $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(NVCC_ARCH_FLAGS) $(EXTRA_CFLAGS)  $(ALL_CCFLAGS) $(GENCODE_FLAGS)  -c $(builddir)./src/types.c -shared -Xcompiler -fPIC -o .libs/types.o
+	$(CC)    -I. $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(CC_ARCH_FLAGS) $(EXTRA_CFLAGS)  $(ALL_CCFLAGS) $(GENCODE_FLAGS)  -c $(builddir)./src/ndarray_types.c -shared -fPIC -o .libs/ndarray_types.o
 	$(CC)    -I. $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(CC_ARCH_FLAGS) $(EXTRA_CFLAGS)  $(ALL_CCFLAGS) $(GENCODE_FLAGS)  -c $(builddir)./src/ndmath/arithmetics.c -shared -fPIC -o .libs/arithmetics.o
 	$(NVCC)  -I. $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(NVCC_ARCH_FLAGS) $(EXTRA_CFLAGS)  $(ALL_CCFLAGS) $(GENCODE_FLAGS)  -c $(builddir)./src/ndmath/double_math.c -shared -Xcompiler -fPIC -o .libs/double_math.o
 	$(CC)    -I. $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(CC_ARCH_FLAGS) $(EXTRA_CFLAGS)  $(ALL_CCFLAGS) $(GENCODE_FLAGS)  -c $(builddir)./src/ndmath/linalg.c -shared -fPIC -o .libs/linalg.o
@@ -92,7 +93,7 @@ install-cuda:
 	$(NVCC)  -I. $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(NVCC_ARCH_FLAGS) $(EXTRA_CFLAGS)  $(ALL_CCFLAGS) $(GENCODE_FLAGS)  -c $(builddir)./src/ndmath/statistics.c -shared -Xcompiler -fPIC -o .libs/statistics.o
 	$(NVCC)  -shared .libs/numpower.o .libs/signal.o .libs/initializers.o .libs/double_math.o .libs/ndarray.o .libs/debug.o .libs/statistics.o .libs/calculation.o .libs/buffer.o .libs/dnn.o \
 	.libs/cuda_dnn.o .libs/logic.o .libs/gpu_alloc.o .libs/linalg.o .libs/manipulation.o .libs/iterators.o .libs/indexing.o .libs/arithmetics.o .libs/types.o .libs/sanitizers.o  \
-	.libs/ndarray__frontend__ndarray_factory.o .libs/ndarray__frontend__manipulations.o .libs/cuda_math.o $(CFLAGS_CLEAN) -o .libs/ndarray.so
+	.libs/ndarray__frontend__ndarray_factory.o .libs/ndarray__frontend__manipulations.o .libs/cuda_math.o .libs/ndarray_types.o $(CFLAGS_CLEAN) -o .libs/ndarray.so
 	cp ./.libs/ndarray.so $(phplibdir)/ndarray.so
 	cp ./.libs/ndarray.so $(EXTENSION_DIR)/ndarray.so
 

--- a/config.m4
+++ b/config.m4
@@ -120,6 +120,7 @@ if test "$PHP_NDARRAY" != "no"; then
       src/ndmath/signal.c \
       src/sanitizers.c \
       src/types.c \
+      src/ndarray_types.c \
       src/ndarray/frontend/ndarray_factory.c \
       src/ndarray/frontend/manipulations.c,
       $ext_shared)

--- a/numpower.c
+++ b/numpower.c
@@ -162,12 +162,25 @@ PHP_METHOD(NDArray, __construct) {
         dataTypeLen = sizeof("float32") - 1;
     }
 
-    if (dataTypeLen == 7 && memcmp(dataType, "float32", 7) == 0) {
-        ndarrayDataType = NDARRAY_TYPE_FLOAT32;
-    } else if (dataTypeLen == 7 && memcmp(dataType, "float64", 7) == 0) {
-        ndarrayDataType = NDARRAY_TYPE_FLOAT64;
-    } else {
-        zend_throw_error(NULL, "Invalid data type. Supported types are: float32, float64");
+    if      (!strcmp(dataType, "float4"))   ndarrayDataType = NDARRAY_TYPE_FLOAT4;
+    else if (!strcmp(dataType, "float8"))   ndarrayDataType = NDARRAY_TYPE_FLOAT8;
+    else if (!strcmp(dataType, "float16"))  ndarrayDataType = NDARRAY_TYPE_FLOAT16;
+    else if (!strcmp(dataType, "float32"))  ndarrayDataType = NDARRAY_TYPE_FLOAT32;
+    else if (!strcmp(dataType, "float64"))  ndarrayDataType = NDARRAY_TYPE_FLOAT64;
+    else if (!strcmp(dataType, "float128")) ndarrayDataType = NDARRAY_TYPE_FLOAT128;
+    else if (!strcmp(dataType, "int8"))     ndarrayDataType = NDARRAY_TYPE_INT8;
+    else if (!strcmp(dataType, "uint8"))    ndarrayDataType = NDARRAY_TYPE_UINT8;
+    else if (!strcmp(dataType, "int16"))    ndarrayDataType = NDARRAY_TYPE_INT16;
+    else if (!strcmp(dataType, "uint16"))   ndarrayDataType = NDARRAY_TYPE_UINT16;
+    else if (!strcmp(dataType, "int32"))    ndarrayDataType = NDARRAY_TYPE_INT32;
+    else if (!strcmp(dataType, "uint32"))   ndarrayDataType = NDARRAY_TYPE_UINT32;
+    else if (!strcmp(dataType, "int64"))    ndarrayDataType = NDARRAY_TYPE_INT64;
+    else if (!strcmp(dataType, "uint64"))   ndarrayDataType = NDARRAY_TYPE_UINT64;
+    else {
+        zend_throw_error(NULL,
+            "Invalid data type '%s'. Supported: float4, float8, float16, float32, float64, "
+            "float128, int8, uint8, int16, uint16, int32, uint32, int64, uint64", dataType);
+        return;
     }
 
     NDArray* array = NDArrayFactory_createFromZval(input, ndarrayDataType);
@@ -374,12 +387,22 @@ typedef struct {
 
 static int ndarray_do_operation_ex(zend_uchar opcode, zval *result, zval *op1, zval *op2) { /* {{{ */
 
+    /* Return FAILURE early for opcodes we don't handle so PHP can fall back
+       to __toString for string concatenation instead of crashing on ZVAL_TO_NDARRAY. */
+    switch (opcode) {
+        case ZEND_ADD: case ZEND_SUB: case ZEND_MUL:
+        case ZEND_DIV: case ZEND_POW: case ZEND_MOD:
+            break;
+        default:
+            return FAILURE;
+    }
+
     zend_object *obj = Z_OBJ_P(op1);
 
     NDArray *nda = ZVAL_TO_NDARRAY(op1);
     NDArray *ndb = ZVAL_TO_NDARRAY(op2);
 
-    if (nda == NULL | ndb == NULL) {
+    if (nda == NULL || ndb == NULL) {
         return FAILURE;
     }
 

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -35,7 +35,9 @@ void buffer_init(int size) {
     MAIN_MEM_STACK.buffer = (NDArray**)emalloc(size * sizeof(NDArray*));
     MAIN_MEM_STACK.bufferSize = size;
     MAIN_MEM_STACK.numElements = 0;
-    MAIN_MEM_STACK.lastFreed = -1;
+    MAIN_MEM_STACK.freeList = (int*)emalloc(size * sizeof(int));
+    MAIN_MEM_STACK.freeListSize = size;
+    MAIN_MEM_STACK.freeListTop = -1;
     MAIN_MEM_STACK.totalGPUAllocated = 0;
     MAIN_MEM_STACK.totalAllocated = 0;
     MAIN_MEM_STACK.totalFreed = 0;
@@ -54,6 +56,12 @@ void buffer_free() {
         MAIN_MEM_STACK.buffer = NULL;
         MAIN_MEM_STACK.numElements = 0;
         MAIN_MEM_STACK.bufferSize = 0;
+    }
+    if (MAIN_MEM_STACK.freeList != NULL) {
+        efree(MAIN_MEM_STACK.freeList);
+        MAIN_MEM_STACK.freeList = NULL;
+        MAIN_MEM_STACK.freeListSize = 0;
+        MAIN_MEM_STACK.freeListTop = -1;
     }
 
 #ifdef ZTS
@@ -85,15 +93,31 @@ void buffer_ndarray_free(int uuid) {
     tsrm_mutex_lock(MAIN_MEM_STACK.lock);
 #endif
 
-    if (MAIN_MEM_STACK.buffer != NULL && 
-        uuid >= 0 && 
-        uuid < MAIN_MEM_STACK.numElements && 
+    if (MAIN_MEM_STACK.buffer != NULL &&
+        uuid >= 0 &&
+        uuid < MAIN_MEM_STACK.numElements &&
         MAIN_MEM_STACK.buffer[uuid] != NULL) {
-        
+
         NDArray_FREE(MAIN_MEM_STACK.buffer[uuid]);
         MAIN_MEM_STACK.buffer[uuid] = NULL;
-        MAIN_MEM_STACK.lastFreed = uuid;
         MAIN_MEM_STACK.totalFreed++;
+
+        /* Push freed UUID onto the free-list so it can be reused. */
+        int top = MAIN_MEM_STACK.freeListTop + 1;
+        if (top >= MAIN_MEM_STACK.freeListSize) {
+            int newSize = MAIN_MEM_STACK.freeListSize * 2;
+            int *newList = (int*)erealloc(MAIN_MEM_STACK.freeList, newSize * sizeof(int));
+            if (newList) {
+                MAIN_MEM_STACK.freeList = newList;
+                MAIN_MEM_STACK.freeListSize = newSize;
+            } else {
+                top = -1; /* realloc failed, drop this slot */
+            }
+        }
+        if (top >= 0) {
+            MAIN_MEM_STACK.freeList[top] = uuid;
+            MAIN_MEM_STACK.freeListTop = top;
+        }
     }
 
 #ifdef ZTS
@@ -132,33 +156,34 @@ void add_to_buffer(NDArray* ndarray) {
         buffer_init(1);
     }
 
-    if (MAIN_MEM_STACK.lastFreed > -1) {
-        ndarray->uuid = MAIN_MEM_STACK.lastFreed;
-        MAIN_MEM_STACK.buffer[MAIN_MEM_STACK.lastFreed] = ndarray;
-        MAIN_MEM_STACK.lastFreed = -1;
+    /* Pop a free slot from the stack if available. */
+    if (MAIN_MEM_STACK.freeListTop >= 0) {
+        int reuse = MAIN_MEM_STACK.freeList[MAIN_MEM_STACK.freeListTop];
+        MAIN_MEM_STACK.freeListTop--;
+        ndarray->uuid = reuse;
+        MAIN_MEM_STACK.buffer[reuse] = ndarray;
 #ifdef ZTS
         tsrm_mutex_unlock(MAIN_MEM_STACK.lock);
 #endif
         return;
     }
 
-    if (MAIN_MEM_STACK.numElements >= MAIN_MEM_STACK.bufferSize && ndarray->uuid == -1) {
-        int newSize = MAIN_MEM_STACK.bufferSize * 2;
-        NDArray** newBuffer = (NDArray**)erealloc(MAIN_MEM_STACK.buffer, 
-                                newSize * sizeof(NDArray*));
-        if (!newBuffer) {
-            php_error_docref(NULL, E_WARNING, 
-                "Failed to allocate memory for the buffer");
-#ifdef ZTS
-            tsrm_mutex_unlock(MAIN_MEM_STACK.lock);
-#endif
-            return;
-        }
-        MAIN_MEM_STACK.buffer = newBuffer;
-        MAIN_MEM_STACK.bufferSize = newSize;
-    }
-
     if (ndarray->uuid == -1) {
+        if (MAIN_MEM_STACK.numElements >= MAIN_MEM_STACK.bufferSize) {
+            int newSize = MAIN_MEM_STACK.bufferSize * 2;
+            NDArray** newBuffer = (NDArray**)erealloc(MAIN_MEM_STACK.buffer,
+                                    newSize * sizeof(NDArray*));
+            if (!newBuffer) {
+                php_error_docref(NULL, E_WARNING,
+                    "Failed to allocate memory for the buffer");
+#ifdef ZTS
+                tsrm_mutex_unlock(MAIN_MEM_STACK.lock);
+#endif
+                return;
+            }
+            MAIN_MEM_STACK.buffer = newBuffer;
+            MAIN_MEM_STACK.bufferSize = newSize;
+        }
         ndarray->uuid = MAIN_MEM_STACK.numElements;
         MAIN_MEM_STACK.buffer[MAIN_MEM_STACK.numElements] = ndarray;
         MAIN_MEM_STACK.numElements++;

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -9,7 +9,9 @@ struct MemoryStack {
     NDArray** buffer;   // Dynamic array to store NDArray pointers
     int bufferSize;     // Current size of the buffer
     int numElements;
-    int lastFreed;
+    int *freeList;      // Stack of freed UUIDs available for reuse
+    int freeListSize;   // Capacity of freeList
+    int freeListTop;    // Index of next slot to pop (-1 = empty)
     int totalGPUAllocated;
     int totalAllocated;
     int totalFreed;

--- a/src/debug.c
+++ b/src/debug.c
@@ -4,6 +4,9 @@
 #include "debug.h"
 #include "../config.h"
 #include "ndarray.h"
+#include "ndarray_types.h"
+#include "types.h"
+#include <string.h>
 
 #ifdef HAVE_CUBLAS
 #include <cuda_runtime.h>
@@ -373,6 +376,122 @@ print_matrix_float64(double* buffer, int ndims, int* shape, int* strides, int nu
     if (device == NDARRAY_DEVICE_GPU) {
         efree(tmp_buffer);
     }
+#endif
+    return rtn;
+}
+
+/* ── Generic array printer for all non-float32/float64 dtypes ─────────────
+   Uses ndarray_element_to_string() so it handles every supported type.   */
+
+static char *print_array_generic(
+    const char *type,
+    const char *data,
+    int ndims, int *shape, int *strides,
+    int cur_dim, int *index,
+    long num_elements, int *padded)
+{
+    char elem_buf[64];
+    int  i, j, t;
+    int  reverse_run = 0;
+
+    if (num_elements == 0) {
+        char *s = (char *)emalloc(3);
+        strcpy(s, "[]");
+        return s;
+    }
+
+    /* Allocate a buffer large enough for this sub-array.
+       Each element needs at most 48 chars + separators. */
+    size_t max_sz = (size_t)num_elements * 52 + (size_t)ndims * 8 + 64;
+    if (max_sz < 256) max_sz = 256;
+    char *str = (char *)emalloc(max_sz);
+    if (!str) return NULL;
+    str[0] = '\0';
+
+    if (ndims == 0) {
+        ndarray_element_to_string(type, data, 0, elem_buf, sizeof(elem_buf));
+        snprintf(str, max_sz, "%s\n", elem_buf);
+        return str;
+    }
+
+    if (cur_dim == ndims - 1) {
+        strcat(str, "[");
+        for (i = 0; i < shape[cur_dim]; i++) {
+            index[cur_dim] = i;
+            int offset = 0;
+            for (int k = 0; k < ndims; k++) offset += index[k] * strides[k];
+            ndarray_element_to_string(type, data, (size_t)offset, elem_buf, sizeof(elem_buf));
+            strcat(str, elem_buf);
+            if (i < shape[cur_dim] - 1) strcat(str, ", ");
+            if ((i + 1) % 10 == 0 && i < shape[cur_dim] - 1) {
+                strcat(str, "\n");
+                for (t = 0; t < ndims; t++) strcat(str, " ");
+            }
+            if (shape[cur_dim] > 20 && i > 1 && reverse_run == 0) {
+                i = shape[cur_dim] - 4;
+                reverse_run = 1;
+                strcat(str, "... ");
+            }
+        }
+        strcat(str, "]");
+        if (cur_dim > 0 && index[cur_dim - 1] < shape[ndims - 2] - 1) strcat(str, "\n ");
+    } else {
+        strcat(str, "[");
+        for (i = 0; i < shape[cur_dim]; i++) {
+            index[cur_dim] = i;
+            char *child = print_array_generic(type, data, ndims, shape, strides,
+                                              cur_dim + 1, index, num_elements, padded);
+            strcat(str, child);
+            efree(child);
+            if (i < shape[cur_dim] - 1) {
+                for (j = 0; j < cur_dim; j++) strcat(str, " ");
+            }
+            if (ndims > 1 && shape[ndims - 1] * shape[ndims - 2] > 500 && shape[cur_dim] > 10) {
+                if (i >= 2 && reverse_run == 0) {
+                    i = shape[cur_dim] - 4;
+                    reverse_run = 1;
+                    strcat(str, "...\n");
+                    if (i < shape[cur_dim] - 1) {
+                        for (j = 1; j < ndims; j++) strcat(str, " ");
+                    }
+                    *padded = 1;
+                }
+            }
+        }
+        strcat(str, "]");
+        if (cur_dim != 0 && index[cur_dim - 1] < shape[cur_dim - 1] - 1) strcat(str, "\n");
+    }
+
+    if (cur_dim == 0) strcat(str, "\n");
+    return str;
+}
+
+char *print_matrix_generic(
+    const char *type,
+    const char *data,
+    int ndims, int *shape, int *strides,
+    long num_elements, int device)
+{
+    const char *tmp = data;
+    char       *gpu_buf = NULL;
+    int         elsize = get_type_size(type);
+
+    if (device == NDARRAY_DEVICE_GPU) {
+#ifdef HAVE_CUBLAS
+        gpu_buf = (char *)emalloc((size_t)num_elements * (size_t)elsize);
+        cudaMemcpy(gpu_buf, data, (size_t)num_elements * (size_t)elsize, cudaMemcpyDeviceToHost);
+        tmp = gpu_buf;
+#endif
+    }
+
+    int *index = (int *)emalloc((size_t)(ndims > 0 ? ndims : 1) * sizeof(int));
+    memset(index, 0, (size_t)(ndims > 0 ? ndims : 1) * sizeof(int));
+    int  padded = 0;
+    char *rtn = print_array_generic(type, tmp, ndims, shape, strides, 0, index, num_elements, &padded);
+    efree(index);
+
+#ifdef HAVE_CUBLAS
+    if (gpu_buf) efree(gpu_buf);
 #endif
     return rtn;
 }

--- a/src/debug.h
+++ b/src/debug.h
@@ -6,13 +6,18 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-void NDArray_Dump(NDArray* array);
-char* print_matrix_float64(double* buffer, int ndims, int* shape, int* strides, int num_elements, int device);
-char* print_matrix_float32(float* buffer, int ndims, int* shape, int* strides, int num_elements, int device);
-void NDArrayIterator_DUMP(NDArray *a);
-void NDArray_DumpDevices();
+
+void  NDArray_Dump(NDArray *array);
+char *print_matrix_float64(double *buffer, int ndims, int *shape, int *strides, int num_elements, int device);
+char *print_matrix_float32(float  *buffer, int ndims, int *shape, int *strides, int num_elements, int device);
+char *print_matrix_generic(const char *type, const char *data,
+                            int ndims, int *shape, int *strides,
+                            long num_elements, int device);
+void  NDArrayIterator_DUMP(NDArray *a);
+void  NDArray_DumpDevices(void);
+
 #ifdef __cplusplus
 }
 #endif
 
-#endif //PHPSCI_NDARRAY_DEBUG_H
+#endif /* PHPSCI_NDARRAY_DEBUG_H */

--- a/src/initializers.c
+++ b/src/initializers.c
@@ -511,27 +511,19 @@ NDArray_Empty(int *shape, int ndim, const char *type, int device) {
         return rtn;
     }
 
-    if (is_type(type, NDARRAY_TYPE_FLOAT32)) {
-        if (device == NDARRAY_DEVICE_CPU) {
-            rtn->device = NDARRAY_DEVICE_CPU;
-            rtn->data = emalloc(NDArray_NUMELEMENTS(rtn) * sizeof(float));
-        } else {
-#ifdef HAVE_CUBLAS
-            rtn->device = NDARRAY_DEVICE_GPU;
-            vmalloc((void **) &rtn->data, NDArray_NUMELEMENTS(rtn) * sizeof(float));
-#endif
-        }
-    } else {
-        if (device == NDARRAY_DEVICE_CPU) {
-            rtn->device = NDARRAY_DEVICE_CPU;
-            rtn->data = emalloc(NDArray_NUMELEMENTS(rtn) * sizeof(double));
-        } else {
-#ifdef HAVE_CUBLAS
-            rtn->device = NDARRAY_DEVICE_GPU;
-            vmalloc((void **) &rtn->data, NDArray_NUMELEMENTS(rtn) * sizeof(double));
-#endif
-        }
+    int elsize = get_type_size(type);
+    if (elsize == 0) return NULL;
+
+    if (device == NDARRAY_DEVICE_CPU) {
+        rtn->device = NDARRAY_DEVICE_CPU;
+        rtn->data = emalloc((size_t)NDArray_NUMELEMENTS(rtn) * (size_t)elsize);
     }
+#ifdef HAVE_CUBLAS
+    else {
+        rtn->device = NDARRAY_DEVICE_GPU;
+        vmalloc((void **)&rtn->data, (size_t)NDArray_NUMELEMENTS(rtn) * (size_t)elsize);
+    }
+#endif
     return rtn;
 }
 
@@ -560,24 +552,18 @@ NDArray_Zeros(int *shape, int ndim, const char *type, const int device) {
         return rtn;
     }
 
+    int elsize = get_type_size(type);
+    if (elsize == 0) return NULL;
+
+    size_t total = (size_t)rtn->descriptor->numElements * (size_t)elsize;
+
     if (device == NDARRAY_DEVICE_CPU) {
-        if (is_type(type, NDARRAY_TYPE_FLOAT64)) {
-            rtn->data = ecalloc(rtn->descriptor->numElements, sizeof(double));
-        }
-        if (is_type(type, NDARRAY_TYPE_FLOAT32)) {
-            rtn->data = ecalloc(rtn->descriptor->numElements, sizeof(float));
-        }
+        rtn->data = ecalloc(rtn->descriptor->numElements, (size_t)elsize);
     }
 #ifdef HAVE_CUBLAS
     if (device == NDARRAY_DEVICE_GPU) {
-        if (is_type(type, NDARRAY_TYPE_FLOAT64)) {
-            vmalloc((void**)(&rtn->data), rtn->descriptor->numElements * sizeof(double));
-            cudaMemset(rtn->data, 0, rtn->descriptor->numElements * sizeof(double));
-        }
-        if (is_type(type, NDARRAY_TYPE_FLOAT32)) {
-            vmalloc((void**)(&rtn->data), rtn->descriptor->numElements * sizeof(float));
-            cudaMemset(rtn->data, 0, rtn->descriptor->numElements * sizeof(float));
-        }
+        vmalloc((void **)(&rtn->data), total);
+        cudaMemset(rtn->data, 0, total);
     }
 #endif
     return rtn;

--- a/src/ndarray.c
+++ b/src/ndarray.c
@@ -720,16 +720,19 @@ char *NDArray_Print(NDArray *array, int do_return) {
 
     if (is_type(NDArray_TYPE(array), NDARRAY_TYPE_FLOAT64)) {
         str = print_matrix_float64(NDArray_F64DATA(array), NDArray_NDIM(array), NDArray_SHAPE(array),
-                                   NDArray_STRIDES(array), NDArray_NUMELEMENTS(array), NDArray_DEVICE(array));
-    }
-
-    if (is_type(NDArray_TYPE(array), NDARRAY_TYPE_FLOAT32)) {
+                                   NDArray_STRIDES(array), (int)NDArray_NUMELEMENTS(array), NDArray_DEVICE(array));
+    } else if (is_type(NDArray_TYPE(array), NDARRAY_TYPE_FLOAT32)) {
         str = print_matrix_float32(NDArray_F32DATA(array), NDArray_NDIM(array), NDArray_SHAPE(array),
+                                   NDArray_STRIDES(array), (int)NDArray_NUMELEMENTS(array), NDArray_DEVICE(array));
+    } else {
+        str = print_matrix_generic(NDArray_TYPE(array), (const char *)NDArray_DATA(array),
+                                   NDArray_NDIM(array), NDArray_SHAPE(array),
                                    NDArray_STRIDES(array), NDArray_NUMELEMENTS(array), NDArray_DEVICE(array));
     }
 
     if (do_return == 0) {
         printf("%s", str);
+        efree(str);
         return NULL;
     }
 
@@ -1193,10 +1196,12 @@ NDArray_ToCPU(NDArray *target) {
     new_shape = emalloc(sizeof(int) * NDArray_NDIM(target));
     memcpy(new_shape, NDArray_SHAPE(target), sizeof(int) * NDArray_NDIM(target));
 
-    NDArray *rtn = NDArray_Empty(new_shape, n_ndim, NDARRAY_TYPE_FLOAT32, NDARRAY_DEVICE_CPU);
+    NDArray *rtn = NDArray_Empty(new_shape, n_ndim, NDArray_TYPE(target), NDARRAY_DEVICE_CPU);
     rtn->device = NDARRAY_DEVICE_CPU;
 #ifdef HAVE_CUBLAS
-    cudaMemcpy(rtn->data, NDArray_F32DATA(target), NDArray_NUMELEMENTS(target) * sizeof(float), cudaMemcpyDeviceToHost);
+    cudaMemcpy(rtn->data, NDArray_DATA(target),
+               (size_t)NDArray_NUMELEMENTS(target) * (size_t)NDArray_ELSIZE(target),
+               cudaMemcpyDeviceToHost);
 #endif
     return rtn;
 }

--- a/src/ndarray/frontend/ndarray_factory.c
+++ b/src/ndarray/frontend/ndarray_factory.c
@@ -6,8 +6,11 @@
 // ce, phpsci_ce_NDArray
 #include "../../../php_numpower.h"
 
-// NDARRAY_TYPE_FLOAT32, NDARRAY_TYPE_FLOAT64
+// NDARRAY_TYPE_FLOAT32, NDARRAY_TYPE_FLOAT64, …
 #include "../../types.h"
+
+// ndarray_set_from_double, ndarray_set_from_string
+#include "../../ndarray_types.h"
 
 // buffer_get
 #include "../../buffer.h"
@@ -144,28 +147,12 @@ static double zval_to_double_safe(zval *val) {
     }
 }
 
-/**
- * @brief Store a double value into the NDArray at the given index
- *
- * Stores a double value into the raw memory buffer of the NDArray
- * after converting it to the appropriate internal type (float32 or float64).
- *
- * @param[in,out] ndarray Pointer to the NDArray structure. Must be properly initialized.
- * @param[in]     index   Zero-based index into the array. Caller must ensure it's in bounds.
- * @param[in]     value   The value to store, which will be cast according to the array's dtype.
- *
- * @throws Error If the dtype of the NDArray is not supported (e.g., not float32 or float64).
- */
 static void set_ndarray_value(NDArray *ndarray, int index, double value) {
-    if (strcmp(NDArray_TYPE(ndarray), NDARRAY_TYPE_FLOAT32) == 0) {
-        float *data = (float *)NDArray_DATA(ndarray);
-        data[index] = (float)value;
-    } else if (strcmp(NDArray_TYPE(ndarray), NDARRAY_TYPE_FLOAT64) == 0) {
-        double *data = (double *)NDArray_DATA(ndarray);
-        data[index] = value;
-    } else {
-        zend_throw_error(NULL, "Invalid data type. Supported types are: float32, float64");
-    }
+    ndarray_set_from_double(NDArray_TYPE(ndarray), (char *)NDArray_DATA(ndarray), (size_t)index, value);
+}
+
+static void set_ndarray_value_string(NDArray *ndarray, int index, const char *str) {
+    ndarray_set_from_string(NDArray_TYPE(ndarray), (char *)NDArray_DATA(ndarray), (size_t)index, str);
 }
 
 /**
@@ -176,18 +163,47 @@ static void set_ndarray_value(NDArray *ndarray, int index, double value) {
  * @param[in,out] firstIndex  A pointer to the first index
  */
 void _fillFromZendArray(NDArray *ndarray, zend_array *zendArray, int *firstIndex) {
-    zval *element;
+    zval       *element;
+    const char *type = NDArray_TYPE(ndarray);
 
     ZEND_HASH_FOREACH_VAL(zendArray, element)
     {
         ZVAL_DEREF(element);
         if (Z_TYPE_P(element) == IS_ARRAY) {
             _fillFromZendArray(ndarray, Z_ARRVAL_P(element), firstIndex);
-        } else {
-            double value = zval_to_double_safe(element);
-            set_ndarray_value(ndarray, *firstIndex, value);
-            ++(*firstIndex);
+            continue;
         }
+
+        /* String path: lossless for exotic / large-integer types */
+        if (Z_TYPE_P(element) == IS_STRING && type_needs_string_io(type)) {
+            set_ndarray_value_string(ndarray, *firstIndex, Z_STRVAL_P(element));
+            ++(*firstIndex);
+            continue;
+        }
+
+        /* Integer path: avoid double-rounding for large int64/uint64 values. */
+        if (Z_TYPE_P(element) == IS_LONG &&
+            (!strcmp(type, "int64") || !strcmp(type, "uint64") ||
+             !strcmp(type, "int32") || !strcmp(type, "uint32") ||
+             !strcmp(type, "int16") || !strcmp(type, "uint16") ||
+             !strcmp(type, "int8")  || !strcmp(type, "uint8"))) {
+            zend_long lv = Z_LVAL_P(element);
+            if (!strcmp(type, "int64") || !strcmp(type, "uint64")) {
+                char tmp[32];
+                snprintf(tmp, sizeof(tmp), "%lld", (long long)lv);
+                ndarray_set_from_string(type, (char *)NDArray_DATA(ndarray), (size_t)*firstIndex, tmp);
+            } else {
+                ndarray_set_from_double(type, (char *)NDArray_DATA(ndarray), (size_t)*firstIndex, (double)lv);
+            }
+            ++(*firstIndex);
+            continue;
+        }
+
+        /* Default path: convert via double */
+        double value = zval_to_double_safe(element);
+        if (EG(exception)) return;
+        set_ndarray_value(ndarray, *firstIndex, value);
+        ++(*firstIndex);
     } ZEND_HASH_FOREACH_END();
 }
 
@@ -383,26 +399,87 @@ int getObjectUuid(zval *obj) {
  * 
  * @return A pointer to the newly created NDArray, or NULL if the zval is not an array.
  */
+/* Create a 0-dim (scalar) NDArray of [type] from a double value */
+static NDArray *_createScalarFromDouble(double val, const char *type) {
+    int elsize = get_type_size(type);
+    if (elsize == 0) return NULL;
+
+    NDArray *rtn = safe_emalloc(1, sizeof(NDArray), 0);
+    rtn->uuid       = -1;
+    rtn->ndim       = 0;
+    rtn->descriptor = emalloc(sizeof(NDArrayDescriptor));
+    rtn->descriptor->numElements = 1;
+    rtn->descriptor->elsize      = elsize;
+    rtn->descriptor->type        = type;
+    rtn->data       = emalloc((size_t)elsize);
+    rtn->device     = NDARRAY_DEVICE_CPU;
+    rtn->strides    = emalloc(sizeof(int));
+    rtn->dimensions = emalloc(sizeof(int));
+    rtn->iterator   = NULL;
+    rtn->base       = NULL;
+    rtn->refcount   = 1;
+    ndarray_set_from_double(type, rtn->data, 0, val);
+    add_to_buffer(rtn);
+    return rtn;
+}
+
+/* Create a 0-dim (scalar) NDArray of [type] from a string (lossless for exotic types) */
+static NDArray *_createScalarFromString(const char *str, const char *type) {
+    int elsize = get_type_size(type);
+    if (elsize == 0) return NULL;
+
+    NDArray *rtn = safe_emalloc(1, sizeof(NDArray), 0);
+    rtn->uuid       = -1;
+    rtn->ndim       = 0;
+    rtn->descriptor = emalloc(sizeof(NDArrayDescriptor));
+    rtn->descriptor->numElements = 1;
+    rtn->descriptor->elsize      = elsize;
+    rtn->descriptor->type        = type;
+    rtn->data       = emalloc((size_t)elsize);
+    rtn->device     = NDARRAY_DEVICE_CPU;
+    rtn->strides    = emalloc(sizeof(int));
+    rtn->dimensions = emalloc(sizeof(int));
+    rtn->iterator   = NULL;
+    rtn->base       = NULL;
+    rtn->refcount   = 1;
+    ndarray_set_from_string(type, rtn->data, 0, str);
+    add_to_buffer(rtn);
+    return rtn;
+}
+
 NDArray *NDArrayFactory_createFromZval(zval *obj, const char *type) {
     if (Z_TYPE_P(obj) == IS_ARRAY) {
         return _createFromZendArray(Z_ARRVAL_P(obj), type);
     }
 
-    if (Z_TYPE_P(obj) == IS_LONG && type == NDARRAY_TYPE_FLOAT32) {
+    /* Legacy fast paths kept for float32 / float64 */
+    if (Z_TYPE_P(obj) == IS_LONG && is_type(type, NDARRAY_TYPE_FLOAT32)) {
         return _createFloat32FromLongScalar(Z_LVAL_P(obj));
     }
-
-    if (Z_TYPE_P(obj) == IS_DOUBLE && type == NDARRAY_TYPE_FLOAT32) {
+    if (Z_TYPE_P(obj) == IS_DOUBLE && is_type(type, NDARRAY_TYPE_FLOAT32)) {
         return _createFloat32FromDoubleScalar(Z_DVAL_P(obj));
     }
-
-    if (Z_TYPE_P(obj) == IS_LONG && type == NDARRAY_TYPE_FLOAT64) {
+    if (Z_TYPE_P(obj) == IS_LONG && is_type(type, NDARRAY_TYPE_FLOAT64)) {
         return _createDouble64FromLongScalar(Z_LVAL_P(obj));
     }
-
-    if (Z_TYPE_P(obj) == IS_DOUBLE && type == NDARRAY_TYPE_FLOAT64) {
+    if (Z_TYPE_P(obj) == IS_DOUBLE && is_type(type, NDARRAY_TYPE_FLOAT64)) {
         return _createDouble64FromDoubleScalar(Z_DVAL_P(obj));
     }
+
+    /* Generic scalar path for all other types */
+    if (Z_TYPE_P(obj) == IS_LONG) {
+        return _createScalarFromDouble((double)Z_LVAL_P(obj), type);
+    }
+    if (Z_TYPE_P(obj) == IS_DOUBLE) {
+        return _createScalarFromDouble(Z_DVAL_P(obj), type);
+    }
+    if (Z_TYPE_P(obj) == IS_STRING) {
+        if (type_needs_string_io(type)) {
+            return _createScalarFromString(Z_STRVAL_P(obj), type);
+        }
+        return _createScalarFromDouble(zval_to_double_safe(obj), type);
+    }
+
     if (Z_TYPE_P(obj) == IS_OBJECT) {
         zend_class_entry *ce = Z_OBJCE_P(obj);
         if (instanceof_function(ce, phpsci_ce_NDArray)) {
@@ -411,7 +488,6 @@ NDArray *NDArrayFactory_createFromZval(zval *obj, const char *type) {
 #ifdef HAVE_GD
         zend_string *class_name = Z_OBJ_P(obj)->ce->name;
         if (strcmp(ZSTR_VAL(class_name), "GdImage") == 0) {
-
             NDArray *ndarray = NDArray_FromGD(obj, false);
             add_to_buffer(ndarray);
             return ndarray;
@@ -419,7 +495,7 @@ NDArray *NDArrayFactory_createFromZval(zval *obj, const char *type) {
 #endif
     }
 
-    zend_throw_error(NULL, "Argument must be an array if numerics, float, int, GdImage or NDArray.");
+    zend_throw_error(NULL, "Argument must be an array of numerics, float, int, string, GdImage or NDArray.");
     return NULL;
 }
 

--- a/src/ndarray_types.c
+++ b/src/ndarray_types.c
@@ -1,0 +1,366 @@
+#include "ndarray_types.h"
+#include <math.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <inttypes.h>
+
+/* ══════════════════════════════════════════════════════════════════════════
+   float4 – E2M1 format (1 sign | 2 exponent | 1 mantissa), bias = 1
+   16 representable values, stored one per byte (lower nibble).
+   ══════════════════════════════════════════════════════════════════════════ */
+
+static const double FP4_LOOKUP[16] = {
+    /* 0b0000 */  0.0,
+    /* 0b0001 */  0.5,
+    /* 0b0010 */  1.0,
+    /* 0b0011 */  1.5,
+    /* 0b0100 */  2.0,
+    /* 0b0101 */  3.0,
+    /* 0b0110 */  4.0,
+    /* 0b0111 */  6.0,
+    /* 0b1000 */ -0.0,
+    /* 0b1001 */ -0.5,
+    /* 0b1010 */ -1.0,
+    /* 0b1011 */ -1.5,
+    /* 0b1100 */ -2.0,
+    /* 0b1101 */ -3.0,
+    /* 0b1110 */ -4.0,
+    /* 0b1111 */ -6.0,
+};
+
+double ndarray_fp4_to_double(uint8_t nibble) {
+    return FP4_LOOKUP[nibble & 0x0F];
+}
+
+uint8_t ndarray_double_to_fp4(double val) {
+    uint8_t best = 0;
+    double  best_err = fabs(val - FP4_LOOKUP[0]);
+    for (uint8_t i = 1; i < 16; i++) {
+        double err = fabs(val - FP4_LOOKUP[i]);
+        if (err < best_err) {
+            best_err = err;
+            best     = i;
+        }
+    }
+    return best;
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   float8 – E4M3 format (1 sign | 4 exponent | 3 mantissa), bias = 7
+   exp=15 → NaN (any mantissa).  Max normal value ≈ 240.
+   ══════════════════════════════════════════════════════════════════════════ */
+
+double ndarray_fp8_to_double(uint8_t fp8) {
+    int sign = (fp8 >> 7) & 1;
+    int exp  = (fp8 >> 3) & 0xF;
+    int man  = fp8 & 0x7;
+
+    if (exp == 0xF) return NAN;
+
+    double val;
+    if (exp == 0) {
+        val = ((double)man / 8.0) * ldexp(1.0, -6);
+    } else {
+        val = (1.0 + (double)man / 8.0) * ldexp(1.0, exp - 7);
+    }
+    return sign ? -val : val;
+}
+
+uint8_t ndarray_double_to_fp8(double val) {
+    if (isnan(val)) return 0xFF;
+
+    int    sign = (val < 0.0 || (val == 0.0 && (1.0 / val) < 0)) ? 1 : 0;
+    double ax   = fabs(val);
+
+    if (ax == 0.0) return (uint8_t)(sign << 7);
+
+    /* Clamp to max representable: (1 + 7/8) * 2^7 = 240 */
+    if (ax > 240.0) ax = 240.0;
+
+    int    exp;
+    double frac = frexp(ax, &exp); /* ax = frac * 2^exp, frac ∈ [0.5, 1.0) */
+    /* Rewrite: ax = (2*frac) * 2^(exp-1) → biased_exp = (exp-1) + 7 = exp+6 */
+    int biased_exp = exp + 6;
+
+    if (biased_exp <= 0) {
+        /* Subnormal: val = (man/8) * 2^(-6) → man = ax * 8 * 2^6 = ax * 512 */
+        int man = (int)(ax * 512.0 + 0.5);
+        if (man > 7) man = 7;
+        return (uint8_t)((sign << 7) | man);
+    }
+
+    if (biased_exp >= 15) {
+        /* Clamp to max: exp=14, man=7 → (1+7/8)*2^7 = 240 */
+        return (uint8_t)((sign << 7) | (14 << 3) | 7);
+    }
+
+    /* Normal: 1.mmm * 2^(biased_exp-7); 2*frac ∈ [1.0, 2.0) → man = (2*frac-1)*8 */
+    int man = (int)((2.0 * frac - 1.0) * 8.0 + 0.5);
+    if (man > 7) {
+        man = 0;
+        biased_exp++;
+    }
+    if (biased_exp >= 15) {
+        return (uint8_t)((sign << 7) | (14 << 3) | 7);
+    }
+    return (uint8_t)((sign << 7) | ((biased_exp & 0xF) << 3) | (man & 0x7));
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   float16 – IEEE-754 half precision  (1 sign | 5 exponent | 10 mantissa)
+   ══════════════════════════════════════════════════════════════════════════ */
+
+double ndarray_fp16_to_double(uint16_t fp16) {
+    uint32_t sign = (uint32_t)(fp16 >> 15) & 1u;
+    uint32_t exp  = (uint32_t)(fp16 >> 10) & 0x1Fu;
+    uint32_t man  = (uint32_t)(fp16)        & 0x3FFu;
+
+    uint32_t f32;
+    if (exp == 31u) {
+        /* Inf / NaN */
+        f32 = (sign << 31) | 0x7F800000u | (man << 13);
+    } else if (exp == 0u) {
+        if (man == 0u) {
+            f32 = sign << 31;
+        } else {
+            /* Subnormal fp16 → normalised fp32 */
+            exp = 1u;
+            while (!(man & 0x400u)) { man <<= 1; exp--; }
+            man &= 0x3FFu;
+            f32 = (sign << 31) | ((exp + 127u - 15u) << 23) | (man << 13);
+        }
+    } else {
+        f32 = (sign << 31) | ((exp + 127u - 15u) << 23) | (man << 13);
+    }
+
+    float fval;
+    memcpy(&fval, &f32, 4);
+    return (double)fval;
+}
+
+uint16_t ndarray_double_to_fp16(double val) {
+    float f = (float)val;
+    uint32_t u;
+    memcpy(&u, &f, 4);
+
+    uint32_t sign = u >> 31;
+    uint32_t u_exp = (u >> 23) & 0xFFu;
+    uint32_t man  = (u >> 13) & 0x3FFu; /* top 10 bits of 23-bit mantissa */
+
+    if (u_exp == 255u) {
+        /* Inf or NaN */
+        return (uint16_t)((sign << 15) | 0x7C00u | (man ? 0x0200u : 0u));
+    }
+
+    int exp32 = (int)u_exp - 127 + 15; /* rebias for fp16 */
+
+    if (exp32 <= 0) {
+        if (exp32 < -10) return (uint16_t)(sign << 15); /* underflow → ±0 */
+        /* Subnormal fp16 */
+        uint32_t m = ((u >> 23) & 0xFFu) ? ((u & 0x7FFFFFu) | 0x800000u) : 0u;
+        m >>= (1 - exp32 + 13);
+        return (uint16_t)((sign << 15) | (m & 0x3FFu));
+    }
+
+    if (exp32 >= 31) return (uint16_t)((sign << 15) | 0x7C00u); /* Inf */
+
+    return (uint16_t)((sign << 15) | ((uint32_t)exp32 << 10) | man);
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   float128 – __float128 (GCC) or long double fallback
+   ══════════════════════════════════════════════════════════════════════════ */
+
+ndarray_fp128_t ndarray_double_to_fp128(double val) {
+    return (ndarray_fp128_t)val;
+}
+
+ndarray_fp128_t ndarray_ldouble_to_fp128(long double val) {
+    return (ndarray_fp128_t)val;
+}
+
+double ndarray_fp128_to_double(ndarray_fp128_t val) {
+    return (double)val;
+}
+
+void ndarray_fp128_to_string(ndarray_fp128_t val, char *buf, size_t bufsize) {
+#if NDARRAY_HAVE_FLOAT128
+    /* Convert via long double to get ~18-19 significant digits. */
+    long double ld = (long double)val;
+    snprintf(buf, bufsize, "%.18Lg", ld);
+#else
+    snprintf(buf, bufsize, "%.18Lg", (long double)val);
+#endif
+}
+
+ndarray_fp128_t ndarray_string_to_fp128(const char *str) {
+    char *endptr;
+    long double ld = strtold(str, &endptr);
+    return (ndarray_fp128_t)ld;
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   Generic element I/O
+   ══════════════════════════════════════════════════════════════════════════ */
+
+void ndarray_element_to_string(const char *type,
+                                const char *data,
+                                size_t      byte_offset,
+                                char       *buf,
+                                size_t      bufsize)
+{
+    if (strcmp(type, "float4") == 0) {
+        uint8_t nibble = (uint8_t)(((const uint8_t *)data)[byte_offset] & 0x0Fu);
+        snprintf(buf, bufsize, "%g", ndarray_fp4_to_double(nibble));
+
+    } else if (strcmp(type, "float8") == 0) {
+        uint8_t fp8 = ((const uint8_t *)data)[byte_offset];
+        double  v   = ndarray_fp8_to_double(fp8);
+        if (isnan(v)) {
+            snprintf(buf, bufsize, "nan");
+        } else {
+            snprintf(buf, bufsize, "%g", v);
+        }
+
+    } else if (strcmp(type, "float16") == 0) {
+        uint16_t fp16;
+        memcpy(&fp16, data + byte_offset, 2);
+        snprintf(buf, bufsize, "%.6g", ndarray_fp16_to_double(fp16));
+
+    } else if (strcmp(type, "float32") == 0) {
+        float v;
+        memcpy(&v, data + byte_offset, 4);
+        snprintf(buf, bufsize, "%.8g", (double)v);
+
+    } else if (strcmp(type, "float64") == 0) {
+        double v;
+        memcpy(&v, data + byte_offset, 8);
+        snprintf(buf, bufsize, "%.16g", v);
+
+    } else if (strcmp(type, "float128") == 0) {
+        ndarray_fp128_t v;
+        memcpy(&v, data + byte_offset, NDARRAY_FP128_SIZE);
+        ndarray_fp128_to_string(v, buf, bufsize);
+
+    } else if (strcmp(type, "int8") == 0) {
+        int8_t v = (int8_t)((const uint8_t *)data)[byte_offset];
+        snprintf(buf, bufsize, "%d", (int)v);
+
+    } else if (strcmp(type, "uint8") == 0) {
+        uint8_t v = ((const uint8_t *)data)[byte_offset];
+        snprintf(buf, bufsize, "%u", (unsigned)v);
+
+    } else if (strcmp(type, "int16") == 0) {
+        int16_t v;
+        memcpy(&v, data + byte_offset, 2);
+        snprintf(buf, bufsize, "%d", (int)v);
+
+    } else if (strcmp(type, "uint16") == 0) {
+        uint16_t v;
+        memcpy(&v, data + byte_offset, 2);
+        snprintf(buf, bufsize, "%u", (unsigned)v);
+
+    } else if (strcmp(type, "int32") == 0) {
+        int32_t v;
+        memcpy(&v, data + byte_offset, 4);
+        snprintf(buf, bufsize, "%" PRId32, v);
+
+    } else if (strcmp(type, "uint32") == 0) {
+        uint32_t v;
+        memcpy(&v, data + byte_offset, 4);
+        snprintf(buf, bufsize, "%" PRIu32, v);
+
+    } else if (strcmp(type, "int64") == 0) {
+        int64_t v;
+        memcpy(&v, data + byte_offset, 8);
+        snprintf(buf, bufsize, "%" PRId64, v);
+
+    } else if (strcmp(type, "uint64") == 0) {
+        uint64_t v;
+        memcpy(&v, data + byte_offset, 8);
+        snprintf(buf, bufsize, "%" PRIu64, v);
+
+    } else {
+        snprintf(buf, bufsize, "?");
+    }
+}
+
+void ndarray_set_from_double(const char *type, char *data, size_t index, double val)
+{
+    if (strcmp(type, "float4") == 0) {
+        ((uint8_t *)data)[index] = ndarray_double_to_fp4(val);
+
+    } else if (strcmp(type, "float8") == 0) {
+        ((uint8_t *)data)[index] = ndarray_double_to_fp8(val);
+
+    } else if (strcmp(type, "float16") == 0) {
+        uint16_t v = ndarray_double_to_fp16(val);
+        memcpy((uint16_t *)data + index, &v, 2);
+
+    } else if (strcmp(type, "float32") == 0) {
+        float v = (float)val;
+        memcpy((float *)data + index, &v, 4);
+
+    } else if (strcmp(type, "float64") == 0) {
+        memcpy((double *)data + index, &val, 8);
+
+    } else if (strcmp(type, "float128") == 0) {
+        ndarray_fp128_t v = ndarray_double_to_fp128(val);
+        memcpy((ndarray_fp128_t *)data + index, &v, NDARRAY_FP128_SIZE);
+
+    } else if (strcmp(type, "int8") == 0) {
+        ((int8_t *)data)[index] = (int8_t)(int64_t)val;
+
+    } else if (strcmp(type, "uint8") == 0) {
+        ((uint8_t *)data)[index] = (uint8_t)(uint64_t)val;
+
+    } else if (strcmp(type, "int16") == 0) {
+        int16_t v = (int16_t)(int64_t)val;
+        memcpy((int16_t *)data + index, &v, 2);
+
+    } else if (strcmp(type, "uint16") == 0) {
+        uint16_t v = (uint16_t)(uint64_t)val;
+        memcpy((uint16_t *)data + index, &v, 2);
+
+    } else if (strcmp(type, "int32") == 0) {
+        int32_t v = (int32_t)(int64_t)val;
+        memcpy((int32_t *)data + index, &v, 4);
+
+    } else if (strcmp(type, "uint32") == 0) {
+        uint32_t v = (uint32_t)(uint64_t)val;
+        memcpy((uint32_t *)data + index, &v, 4);
+
+    } else if (strcmp(type, "int64") == 0) {
+        int64_t v = (int64_t)val;
+        memcpy((int64_t *)data + index, &v, 8);
+
+    } else if (strcmp(type, "uint64") == 0) {
+        uint64_t v = (uint64_t)val;
+        memcpy((uint64_t *)data + index, &v, 8);
+    }
+}
+
+void ndarray_set_from_string(const char *type, char *data, size_t index, const char *str)
+{
+    if (strcmp(type, "float128") == 0) {
+        ndarray_fp128_t v = ndarray_string_to_fp128(str);
+        memcpy((ndarray_fp128_t *)data + index, &v, NDARRAY_FP128_SIZE);
+
+    } else if (strcmp(type, "uint64") == 0) {
+        char    *endptr;
+        uint64_t v = (uint64_t)strtoull(str, &endptr, 10);
+        memcpy((uint64_t *)data + index, &v, 8);
+
+    } else if (strcmp(type, "int64") == 0) {
+        char   *endptr;
+        int64_t v = (int64_t)strtoll(str, &endptr, 10);
+        memcpy((int64_t *)data + index, &v, 8);
+
+    } else {
+        char   *endptr;
+        double  v = strtod(str, &endptr);
+        ndarray_set_from_double(type, data, index, v);
+    }
+}

--- a/src/ndarray_types.h
+++ b/src/ndarray_types.h
@@ -1,0 +1,56 @@
+#ifndef PHPSCI_NDARRAY_TYPES_EXTRA_H
+#define PHPSCI_NDARRAY_TYPES_EXTRA_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+/* ── float4 : 4-bit float, E2M1 format, stored in lower nibble of uint8_t ─ */
+double  ndarray_fp4_to_double(uint8_t nibble);
+uint8_t ndarray_double_to_fp4(double val);
+
+/* ── float8 : E4M3 8-bit float ─────────────────────────────────────────── */
+double  ndarray_fp8_to_double(uint8_t fp8);
+uint8_t ndarray_double_to_fp8(double val);
+
+/* ── float16 : IEEE-754 half precision ──────────────────────────────────── */
+double   ndarray_fp16_to_double(uint16_t fp16);
+uint16_t ndarray_double_to_fp16(double val);
+
+/* ── float128 : __float128 on GCC/x86-64, long double elsewhere ─────────── */
+#if defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__))
+#  define NDARRAY_HAVE_FLOAT128 1
+   typedef __float128 ndarray_fp128_t;
+#  define NDARRAY_FP128_SIZE 16
+#else
+#  define NDARRAY_HAVE_FLOAT128 0
+   typedef long double ndarray_fp128_t;
+#  define NDARRAY_FP128_SIZE sizeof(long double)
+#endif
+
+ndarray_fp128_t ndarray_double_to_fp128(double val);
+ndarray_fp128_t ndarray_ldouble_to_fp128(long double val);
+double          ndarray_fp128_to_double(ndarray_fp128_t val);
+void            ndarray_fp128_to_string(ndarray_fp128_t val, char *buf, size_t bufsize);
+ndarray_fp128_t ndarray_string_to_fp128(const char *str);
+
+/* ── Generic element I/O ─────────────────────────────────────────────────── */
+
+/* Format the element at [byte_offset] bytes into [data] as a C string.
+   [type] is one of the NDARRAY_TYPE_* constants. [buf] must be at least 48
+   bytes. */
+void ndarray_element_to_string(const char *type,
+                                const char *data,
+                                size_t      byte_offset,
+                                char       *buf,
+                                size_t      bufsize);
+
+/* Store [val] (as double) at element index [index] in [data].
+   Performs the appropriate cast / quantisation for the target type.     */
+void ndarray_set_from_double(const char *type, char *data, size_t index, double val);
+
+/* Store a value parsed from string [str] at element index [index] in [data].
+   Preferred over ndarray_set_from_double for float128 and uint64 to avoid
+   precision loss.                                                           */
+void ndarray_set_from_string(const char *type, char *data, size_t index, const char *str);
+
+#endif /* PHPSCI_NDARRAY_TYPES_EXTRA_H */

--- a/src/types.c
+++ b/src/types.c
@@ -1,30 +1,41 @@
 #include "types.h"
-#include "string.h"
+#include "ndarray_types.h"
+#include <string.h>
 
-/**
- * Get size of a specific NDArray type
- *
- * @param type
- * @return
- */
 int get_type_size(const char *type) {
-    if (!strcmp(type, NDARRAY_TYPE_FLOAT64)) {
-        return sizeof(double);
-    }
-    if (!strcmp(type, NDARRAY_TYPE_FLOAT32)) {
-        return sizeof(float);
-    }
+    if (!strcmp(type, "float4"))   return 1;   /* 4 bits in lower nibble of uint8_t */
+    if (!strcmp(type, "float8"))   return 1;
+    if (!strcmp(type, "float16"))  return 2;
+    if (!strcmp(type, "float32"))  return 4;
+    if (!strcmp(type, "float64"))  return 8;
+    if (!strcmp(type, "float128")) return (int)NDARRAY_FP128_SIZE;
+    if (!strcmp(type, "int8"))     return 1;
+    if (!strcmp(type, "uint8"))    return 1;
+    if (!strcmp(type, "int16"))    return 2;
+    if (!strcmp(type, "uint16"))   return 2;
+    if (!strcmp(type, "int32"))    return 4;
+    if (!strcmp(type, "uint32"))   return 4;
+    if (!strcmp(type, "int64"))    return 8;
+    if (!strcmp(type, "uint64"))   return 8;
     return 0;
 }
 
-/**
- * @param type_a
- * @param type_b
- * @return
- */
 int is_type(const char *type_a, const char *type_b) {
-    if (!strcmp(type_a, type_b)) {
-        return 1;
-    }
+    return strcmp(type_a, type_b) == 0 ? 1 : 0;
+}
+
+int type_needs_string_io(const char *type) {
+    /* Types not natively representable in PHP (int64/uint64 may need strings
+       for values outside PHP_INT range; float4/8/16/128 always need strings
+       for full fidelity). */
+    if (!strcmp(type, "float4"))   return 1;
+    if (!strcmp(type, "float8"))   return 1;
+    if (!strcmp(type, "float16"))  return 1;
+    if (!strcmp(type, "float128")) return 1;
+    if (!strcmp(type, "uint64"))   return 1;
     return 0;
+}
+
+int type_is_valid(const char *type) {
+    return get_type_size(type) > 0;
 }

--- a/src/types.h
+++ b/src/types.h
@@ -1,10 +1,34 @@
 #ifndef PHPSCI_NDARRAY_TYPES_H
 #define PHPSCI_NDARRAY_TYPES_H
 
-static const char* NDARRAY_TYPE_FLOAT32 = "float32";
-static const char* NDARRAY_TYPE_FLOAT64 = "float64";
+#include "ndarray_types.h"
 
+/* All supported dtype strings */
+static const char* NDARRAY_TYPE_FLOAT4   = "float4";
+static const char* NDARRAY_TYPE_FLOAT8   = "float8";
+static const char* NDARRAY_TYPE_FLOAT16  = "float16";
+static const char* NDARRAY_TYPE_FLOAT32  = "float32";
+static const char* NDARRAY_TYPE_FLOAT64  = "float64";
+static const char* NDARRAY_TYPE_FLOAT128 = "float128";
+static const char* NDARRAY_TYPE_INT8     = "int8";
+static const char* NDARRAY_TYPE_UINT8    = "uint8";
+static const char* NDARRAY_TYPE_INT16    = "int16";
+static const char* NDARRAY_TYPE_UINT16   = "uint16";
+static const char* NDARRAY_TYPE_INT32    = "int32";
+static const char* NDARRAY_TYPE_UINT32   = "uint32";
+static const char* NDARRAY_TYPE_INT64    = "int64";
+static const char* NDARRAY_TYPE_UINT64   = "uint64";
+
+/* Returns element size in bytes, or 0 for unknown types */
 int get_type_size(const char *type);
+
+/* Returns 1 if type_a and type_b are the same dtype string */
 int is_type(const char *type_a, const char *type_b);
 
-#endif //PHPSCI_NDARRAY_TYPES_H
+/* Returns 1 if the type needs string-based I/O from PHP (no native PHP representation) */
+int type_needs_string_io(const char *type);
+
+/* Returns 1 if the type is one of the validated dtype strings */
+int type_is_valid(const char *type);
+
+#endif /* PHPSCI_NDARRAY_TYPES_H */

--- a/tests/types/001-dtype-int8.phpt
+++ b/tests/types/001-dtype-int8.phpt
@@ -1,0 +1,9 @@
+--TEST--
+NDArray int8 dtype: creation, display, boundary values
+--FILE--
+<?php
+$a = new NDArray([0, 1, -1, 127, -128], "int8");
+echo $a;
+?>
+--EXPECT--
+[0, 1, -1, 127, -128]

--- a/tests/types/002-dtype-uint8.phpt
+++ b/tests/types/002-dtype-uint8.phpt
@@ -1,0 +1,9 @@
+--TEST--
+NDArray uint8 dtype: creation, display, boundary values
+--FILE--
+<?php
+$a = new NDArray([0, 1, 128, 255], "uint8");
+echo $a;
+?>
+--EXPECT--
+[0, 1, 128, 255]

--- a/tests/types/003-dtype-int16.phpt
+++ b/tests/types/003-dtype-int16.phpt
@@ -1,0 +1,9 @@
+--TEST--
+NDArray int16 dtype: creation, display, boundary values
+--FILE--
+<?php
+$a = new NDArray([0, 1000, -32768, 32767], "int16");
+echo $a;
+?>
+--EXPECT--
+[0, 1000, -32768, 32767]

--- a/tests/types/004-dtype-uint16.phpt
+++ b/tests/types/004-dtype-uint16.phpt
@@ -1,0 +1,9 @@
+--TEST--
+NDArray uint16 dtype: creation, display, boundary values
+--FILE--
+<?php
+$a = new NDArray([0, 1000, 32768, 65535], "uint16");
+echo $a;
+?>
+--EXPECT--
+[0, 1000, 32768, 65535]

--- a/tests/types/005-dtype-int32.phpt
+++ b/tests/types/005-dtype-int32.phpt
@@ -1,0 +1,9 @@
+--TEST--
+NDArray int32 dtype: creation, display, boundary values
+--FILE--
+<?php
+$a = new NDArray([0, 1, -2147483648, 2147483647], "int32");
+echo $a;
+?>
+--EXPECT--
+[0, 1, -2147483648, 2147483647]

--- a/tests/types/006-dtype-uint32.phpt
+++ b/tests/types/006-dtype-uint32.phpt
@@ -1,0 +1,9 @@
+--TEST--
+NDArray uint32 dtype: creation, display, boundary values
+--FILE--
+<?php
+$a = new NDArray([0, 1, 2147483648, 4294967295], "uint32");
+echo $a;
+?>
+--EXPECT--
+[0, 1, 2147483648, 4294967295]

--- a/tests/types/007-dtype-int64.phpt
+++ b/tests/types/007-dtype-int64.phpt
@@ -1,0 +1,9 @@
+--TEST--
+NDArray int64 dtype: creation, display, PHP_INT_MAX/MIN boundary values
+--FILE--
+<?php
+$a = new NDArray([0, 1, -1, PHP_INT_MAX, PHP_INT_MIN], "int64");
+echo $a;
+?>
+--EXPECT--
+[0, 1, -1, 9223372036854775807, -9223372036854775808]

--- a/tests/types/008-dtype-uint64.phpt
+++ b/tests/types/008-dtype-uint64.phpt
@@ -1,0 +1,14 @@
+--TEST--
+NDArray uint64 dtype: creation from strings, display, large values
+--FILE--
+<?php
+// uint64 max exceeds PHP_INT_MAX, so large values must come as strings
+$a = new NDArray(["0", "1", "9223372036854775808", "18446744073709551615"], "uint64");
+echo $a;
+// small values can also be PHP ints
+$b = new NDArray([0, 100, 65535], "uint64");
+echo $b;
+?>
+--EXPECT--
+[0, 1, 9223372036854775808, 18446744073709551615]
+[0, 100, 65535]

--- a/tests/types/009-dtype-float16.phpt
+++ b/tests/types/009-dtype-float16.phpt
@@ -1,0 +1,13 @@
+--TEST--
+NDArray float16 dtype: creation from strings, display, representable values
+--FILE--
+<?php
+$a = new NDArray(["0.5", "-1.5", "2.0", "65504.0"], "float16");
+echo $a;
+$b = new NDArray([["0.5", "1.0"], ["-1.5", "2.0"]], "float16");
+echo $b;
+?>
+--EXPECT--
+[0.5, -1.5, 2, 65504]
+[[0.5, 1]
+ [-1.5, 2]]

--- a/tests/types/010-dtype-float8.phpt
+++ b/tests/types/010-dtype-float8.phpt
@@ -1,0 +1,9 @@
+--TEST--
+NDArray float8 E4M3 dtype: creation from strings, display
+--FILE--
+<?php
+$a = new NDArray(["0.0", "1.0", "-2.0", "240.0"], "float8");
+echo $a;
+?>
+--EXPECT--
+[0, 1, -2, 240]

--- a/tests/types/011-dtype-float4.phpt
+++ b/tests/types/011-dtype-float4.phpt
@@ -1,0 +1,14 @@
+--TEST--
+NDArray float4 E2M1 dtype: creation from strings, all 8 positive representable values
+--FILE--
+<?php
+// All positive float4 E2M1 values: 0, 0.5, 1, 1.5, 2, 3, 4, 6
+$a = new NDArray(["0.0", "0.5", "1.0", "1.5", "2.0", "3.0", "4.0", "6.0"], "float4");
+echo $a;
+// Negative values
+$b = new NDArray(["-0.5", "-1.0", "-2.0", "-6.0"], "float4");
+echo $b;
+?>
+--EXPECT--
+[0, 0.5, 1, 1.5, 2, 3, 4, 6]
+[-0.5, -1, -2, -6]

--- a/tests/types/012-dtype-float128.phpt
+++ b/tests/types/012-dtype-float128.phpt
@@ -1,0 +1,12 @@
+--TEST--
+NDArray float128 dtype: creation from strings, high-precision display
+--FILE--
+<?php
+$a = new NDArray(["1.23456789012345678901234"], "float128");
+echo $a;
+$b = new NDArray(["3.14159265358979323846264338327950288"], "float128");
+echo $b;
+?>
+--EXPECT--
+[1.23456789012345679]
+[3.14159265358979324]

--- a/tests/types/013-dtype-invalid.phpt
+++ b/tests/types/013-dtype-invalid.phpt
@@ -1,0 +1,12 @@
+--TEST--
+NDArray: invalid dtype throws an error
+--FILE--
+<?php
+try {
+    $a = new NDArray([1, 2, 3], "badtype");
+} catch (Error $e) {
+    echo $e->getMessage() . "\n";
+}
+?>
+--EXPECT--
+Invalid data type 'badtype'. Supported: float4, float8, float16, float32, float64, float128, int8, uint8, int16, uint16, int32, uint32, int64, uint64

--- a/tests/types/014-dtype-multidim-int.phpt
+++ b/tests/types/014-dtype-multidim-int.phpt
@@ -1,0 +1,14 @@
+--TEST--
+NDArray integer dtypes: 2D arrays
+--FILE--
+<?php
+$a = new NDArray([[1, 2, 3], [4, 5, 6]], "int32");
+echo $a;
+$b = new NDArray([[0, 255], [128, 64]], "uint8");
+echo $b;
+?>
+--EXPECT--
+[[1, 2, 3]
+ [4, 5, 6]]
+[[0, 255]
+ [128, 64]]


### PR DESCRIPTION
Extends NDArray to 14 data types with CPU and GPU support, fixes a memory leak in the UUID buffer, and resolves a crash during string concatenation (`echo $a . PHP_EOL`).

---

## New Data Types

Support has been added for all data types in both CPU and GPU modes:

| Type          | Format                              | Size      | Input/Output                        |
|----------------|-------------------------------------|------------|-------------------------------------|
| float4         | E2M1 (16 values: 0, ±0.5…±6)        | 1 byte     | strings                             |
| float8         | E4M3 (IEEE-like, max≈240)           | 1 byte     | strings                             |
| float16        | IEEE 754 half-precision             | 2 bytes    | strings                             |
| float32        | IEEE 754 single precision           | 4 bytes    | PHP float                           |
| float64        | IEEE 754 double precision           | 8 bytes    | PHP float                           |
| float128       | `__float128` / `long double`        | 16 bytes   | strings                             |
| int8…int64     | `stdint.h`                          | 1–8 bytes  | PHP int                             |
| uint8…uint32   | `stdint.h`                          | 1–4 bytes  | PHP int                             |
| uint64         | `stdint.h`                          | 8 bytes    | strings (values > `PHP_INT_MAX`)    |

Types that cannot be represented precisely using native PHP `float` or `int` values accept and return data as strings:

```php
$a = new NDArray(['0.5', '1.5', '3.0'], 'float4');      // → [0.5, 1.5, 3]
$b = new NDArray(['18446744073709551615'], 'uint64');   // → [18446744073709551615]
$c = new NDArray(['3.14159265358979324'], 'float128');  // → [3.14159265358979324]