### PR TITLE
new data types for NumPower::array()

### DIFF
--- a/numpower.c
+++ b/numpower.c
@@ -5086,23 +5086,62 @@ PHP_METHOD(NumPower, prod) {
 
 ZEND_BEGIN_ARG_INFO(arginfo_ndarray_array, 0)
 ZEND_ARG_INFO(0, a)
+ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, dtype, IS_STRING, 0, "float64")
 ZEND_END_ARG_INFO()
 PHP_METHOD(NumPower, array) {
-    NDArray *rtn = NULL;
+    NDArray *nda = NULL;
     zval *a;
-    long axis;
-    ZEND_PARSE_PARAMETERS_START(1, 1)
+    char *dataType = NULL;
+    size_t dataTypeLen;
+    const char *ndarrayDataType;
+
+    ZEND_PARSE_PARAMETERS_START(1, 2)
         Z_PARAM_ZVAL(a)
+    Z_PARAM_OPTIONAL
+        Z_PARAM_STRING(dataType, dataTypeLen)
     ZEND_PARSE_PARAMETERS_END();
-    NDArray *nda = ZVAL_TO_NDARRAY(a);
+
+    if (ZEND_NUM_ARGS() < 2) {
+        dataType = "float64";
+        dataTypeLen = sizeof("float64") - 1;
+    }
+
+    if      (!strcmp(dataType, "float4"))   ndarrayDataType = NDARRAY_TYPE_FLOAT4;
+    else if (!strcmp(dataType, "float8"))   ndarrayDataType = NDARRAY_TYPE_FLOAT8;
+    else if (!strcmp(dataType, "float16"))  ndarrayDataType = NDARRAY_TYPE_FLOAT16;
+    else if (!strcmp(dataType, "float32"))  ndarrayDataType = NDARRAY_TYPE_FLOAT32;
+    else if (!strcmp(dataType, "float64"))  ndarrayDataType = NDARRAY_TYPE_FLOAT64;
+    else if (!strcmp(dataType, "float128")) ndarrayDataType = NDARRAY_TYPE_FLOAT128;
+    else if (!strcmp(dataType, "int8"))     ndarrayDataType = NDARRAY_TYPE_INT8;
+    else if (!strcmp(dataType, "uint8"))    ndarrayDataType = NDARRAY_TYPE_UINT8;
+    else if (!strcmp(dataType, "int16"))    ndarrayDataType = NDARRAY_TYPE_INT16;
+    else if (!strcmp(dataType, "uint16"))   ndarrayDataType = NDARRAY_TYPE_UINT16;
+    else if (!strcmp(dataType, "int32"))    ndarrayDataType = NDARRAY_TYPE_INT32;
+    else if (!strcmp(dataType, "uint32"))   ndarrayDataType = NDARRAY_TYPE_UINT32;
+    else if (!strcmp(dataType, "int64"))    ndarrayDataType = NDARRAY_TYPE_INT64;
+    else if (!strcmp(dataType, "uint64"))   ndarrayDataType = NDARRAY_TYPE_UINT64;
+    else {
+        zend_throw_error(NULL,
+            "Invalid data type '%s'. Supported: float4, float8, float16, float32, float64, "
+            "float128, int8, uint8, int16, uint16, int32, uint32, int64, uint64", dataType);
+        return;
+    }
+
+    if (Z_TYPE_P(a) == IS_OBJECT) {
+        zend_class_entry *ce = Z_OBJCE_P(a);
+        if (instanceof_function(ce, phpsci_ce_NDArray)) {
+            ZVAL_COPY(return_value, a);
+            return;
+        }
+    }
+
+    // NDArrayFactory_createFromZval adds the array to the buffer (uuid is set)
+    nda = NDArrayFactory_createFromZval(a, ndarrayDataType);
     if (nda == NULL) {
         return;
     }
-    if (nda->uuid != -1) {
-        ZVAL_COPY(return_value, a);
-    } else {
-        ndarray_init_new_object(nda, return_value);
-    }
+    object_init_ex(return_value, phpsci_ce_NDArray);
+    ZVAL_LONG(OBJ_PROP_NUM(Z_OBJ_P(return_value), 0), NDArray_UUID(nda));
 }
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_slice, 0, 0, IS_MIXED, 0)

--- a/php-tests/NumPower/NumPowerArrayTest.php
+++ b/php-tests/NumPower/NumPowerArrayTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Numpower\Tests\NumPower;
+
+use NDArray;
+use NumPower;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Throwable;
+
+class NumPowerArrayTest extends TestCase
+{
+    public function testDefaultDtypeIsFloat64(): void
+    {
+        $nd = NumPower::array([1, 2.45, 9.2234567890987654]);
+
+        $this->assertEquals(1, $nd[0]);
+        $this->assertEquals(2.45, $nd[1]);
+        $this->assertEquals(9.2234567890987655, $nd[2]);
+    }
+
+    public function testFloat32Dtype(): void
+    {
+        $nd = NumPower::array([1, 2.45, 3.1234567890987654], 'float32');
+
+        $this->assertEquals(1, $nd[0]);
+        $this->assertEquals(2.450000047683716, $nd[1]);
+        $this->assertEquals(3.1234567165374756, $nd[2]);
+    }
+
+    public function testFloat64Dtype(): void
+    {
+        $nd = NumPower::array([1, 2.45, 9.2234567890987654], 'float64');
+
+        $this->assertEquals(1, $nd[0]);
+        $this->assertEquals(2.45, $nd[1]);
+        $this->assertEquals(9.2234567890987655, $nd[2]);
+    }
+
+    public function testFloat32VsFloat64Precision(): void
+    {
+        $f32 = NumPower::array([2.45], 'float32');
+        $f64 = NumPower::array([2.45], 'float64');
+
+        $this->assertNotEquals($f32[0], $f64[0]);
+        $this->assertEquals(2.450000047683716, $f32[0]);
+        $this->assertEquals(2.45, $f64[0]);
+    }
+
+    public function testFloat32_2D(): void
+    {
+        $nd = NumPower::array([[1, 2.45, 3.1234567890987654], [1, 2.45, 3.1234567890987654]], 'float32');
+
+        $this->assertEquals(2.450000047683716, $nd[0][1]);
+        $this->assertEquals(3.1234567165374756, $nd[0][2]);
+        $this->assertEquals(2.450000047683716, $nd[1][1]);
+        $this->assertEquals(3.1234567165374756, $nd[1][2]);
+    }
+
+    public function testFloat64_2D(): void
+    {
+        $nd = NumPower::array([[1, 2.45, 9.2234567890987654], [1, 2.45, 9.2234567890987654]], 'float64');
+
+        $this->assertEquals(2.45, $nd[0][1]);
+        $this->assertEquals(9.2234567890987655, $nd[0][2]);
+        $this->assertEquals(2.45, $nd[1][1]);
+        $this->assertEquals(9.2234567890987655, $nd[1][2]);
+    }
+
+    #[DataProvider('validDtypeProvider')]
+    public function testValidDtypesDoNotThrow(string $dtype): void
+    {
+        $nd = NumPower::array([1, 2, 3], $dtype);
+        $this->assertEquals(1, $nd[0]);
+        $this->assertEquals(2, $nd[1]);
+        $this->assertEquals(3, $nd[2]);
+    }
+
+    public static function validDtypeProvider(): array
+    {
+        return [
+            'float32'  => ['float32'],
+            'float64'  => ['float64'],
+            'int8'     => ['int8'],
+            'uint8'    => ['uint8'],
+            'int16'    => ['int16'],
+            'uint16'   => ['uint16'],
+            'int32'    => ['int32'],
+            'uint32'   => ['uint32'],
+            'int64'    => ['int64'],
+            'uint64'   => ['uint64'],
+        ];
+    }
+
+    public function testInvalidDtypeThrowsError(): void
+    {
+        $this->expectException(Throwable::class);
+        $this->expectExceptionMessage("Invalid data type 'badtype'.");
+
+        NumPower::array([1, 2, 3], 'badtype');
+    }
+
+    public function testInt32BoundaryValues(): void
+    {
+        $nd = NumPower::array([0, 1, -2147483648, 2147483647], 'int32');
+
+        $this->assertEquals(0, $nd[0]);
+        $this->assertEquals(1, $nd[1]);
+        $this->assertEquals(-2147483648, $nd[2]);
+        $this->assertEquals(2147483647, $nd[3]);
+    }
+
+    public function testUint8BoundaryValues(): void
+    {
+        $nd = NumPower::array([0, 127, 255], 'uint8');
+
+        $this->assertEquals(0, $nd[0]);
+        $this->assertEquals(127, $nd[1]);
+        $this->assertEquals(255, $nd[2]);
+    }
+
+    public function testNDArrayInputIsReturnedUnchanged(): void
+    {
+        $a = NumPower::array([1, 2, 3], 'int32');
+        $b = NumPower::array($a);
+
+        $this->assertSame($a, $b);
+    }
+
+    public function testNDArrayInputDtypeParamIgnored(): void
+    {
+        $a = NumPower::array([1, 2, 3], 'int32');
+        $b = NumPower::array($a, 'float64');
+
+        $this->assertSame($a, $b);
+    }
+}

--- a/stubs/numpower.stubs.php
+++ b/stubs/numpower.stubs.php
@@ -789,14 +789,15 @@ final class NumPower {
     public static function columnStack(array $arrays): NumPower {}
 
     /**
-     * Creates a new NumPower from a PHP array.
+     * Creates a new NumPower from a PHP array with an optional data type.
      *
-     * It is the equivalent of `new NumPower($array);`
+     * It is the equivalent of `new NDArray($array, $dtype);`
      *
      * @param array|float|int $array
+     * @param string $dtype Data type: float4, float8, float16, float32, float64, float128, int8, uint8, int16, uint16, int32, uint32, int64, uint64 (default: float64)
      * @return NumPower
      */
-    public static function array(array|float|int $array): NumPower {}
+    public static function array(array|float|int $array, string $dtype = 'float64'): NumPower {}
 
     /**
      * This function returns a square array, where the main diagonal consists of ones and all other

--- a/tests/initializers/002-numpower-array-dtype-float32.phpt
+++ b/tests/initializers/002-numpower-array-dtype-float32.phpt
@@ -1,0 +1,13 @@
+--TEST--
+NumPower::array with float32 dtype
+--FILE--
+<?php
+$a = NumPower::array([1, 2, 3, 4], 'float32');
+echo $a . "\n";
+$b = NumPower::array([[1, 2], [3, 4]], 'float32');
+echo $b . "\n";
+?>
+--EXPECT--
+[1, 2, 3, 4]
+[[1, 2]
+ [3, 4]]

--- a/tests/initializers/003-numpower-array-dtype-float64.phpt
+++ b/tests/initializers/003-numpower-array-dtype-float64.phpt
@@ -1,0 +1,13 @@
+--TEST--
+NumPower::array with explicit float64 dtype
+--FILE--
+<?php
+$a = NumPower::array([1, 2, 3, 4], 'float64');
+echo $a . "\n";
+$b = NumPower::array([[1, 2], [3, 4]], 'float64');
+echo $b . "\n";
+?>
+--EXPECT--
+[1, 2, 3, 4]
+[[1, 2]
+ [3, 4]]

--- a/tests/initializers/004-numpower-array-dtype-default.phpt
+++ b/tests/initializers/004-numpower-array-dtype-default.phpt
@@ -1,0 +1,13 @@
+--TEST--
+NumPower::array without dtype uses float64 by default
+--FILE--
+<?php
+$a = NumPower::array([1, 2, 3]);
+echo $a . "\n";
+$b = NumPower::array([[1, 2], [3, 4]]);
+echo $b . "\n";
+?>
+--EXPECT--
+[1, 2, 3]
+[[1, 2]
+ [3, 4]]

--- a/tests/initializers/005-numpower-array-dtype-int32.phpt
+++ b/tests/initializers/005-numpower-array-dtype-int32.phpt
@@ -1,0 +1,9 @@
+--TEST--
+NumPower::array with int32 dtype: boundary values
+--FILE--
+<?php
+$a = NumPower::array([0, 1, -2147483648, 2147483647], 'int32');
+echo $a . "\n";
+?>
+--EXPECT--
+[0, 1, -2147483648, 2147483647]

--- a/tests/initializers/006-numpower-array-dtype-uint8.phpt
+++ b/tests/initializers/006-numpower-array-dtype-uint8.phpt
@@ -1,0 +1,9 @@
+--TEST--
+NumPower::array with uint8 dtype: boundary values
+--FILE--
+<?php
+$a = NumPower::array([0, 1, 127, 255], 'uint8');
+echo $a . "\n";
+?>
+--EXPECT--
+[0, 1, 127, 255]

--- a/tests/initializers/007-numpower-array-dtype-invalid.phpt
+++ b/tests/initializers/007-numpower-array-dtype-invalid.phpt
@@ -1,0 +1,12 @@
+--TEST--
+NumPower::array with invalid dtype throws an error
+--FILE--
+<?php
+try {
+    $a = NumPower::array([1, 2, 3], 'badtype');
+} catch (Error $e) {
+    echo $e->getMessage() . "\n";
+}
+?>
+--EXPECT--
+Invalid data type 'badtype'. Supported: float4, float8, float16, float32, float64, float128, int8, uint8, int16, uint16, int32, uint32, int64, uint64

--- a/tests/initializers/008-numpower-array-dtype-2d.phpt
+++ b/tests/initializers/008-numpower-array-dtype-2d.phpt
@@ -1,0 +1,14 @@
+--TEST--
+NumPower::array with dtype on 2D arrays
+--FILE--
+<?php
+$a = NumPower::array([[1, 2, 3], [4, 5, 6]], 'int32');
+echo $a . "\n";
+$b = NumPower::array([[0, 255], [128, 64]], 'uint8');
+echo $b . "\n";
+?>
+--EXPECT--
+[[1, 2, 3]
+ [4, 5, 6]]
+[[0, 255]
+ [128, 64]]

--- a/tests/initializers/009-numpower-array-ndarray-input.phpt
+++ b/tests/initializers/009-numpower-array-ndarray-input.phpt
@@ -1,0 +1,12 @@
+--TEST--
+NumPower::array with NDArray input returns the same object
+--FILE--
+<?php
+$a = NumPower::array([1, 2, 3], 'int32');
+$b = NumPower::array($a);
+echo $b . "\n";
+var_dump($a === $b);
+?>
+--EXPECT--
+[1, 2, 3]
+bool(true)


### PR DESCRIPTION
Added optional `$dtype` parameter to `NumPower::array()`, making it equivalent to the `NDArray` constructor in terms of type control.

  ### Before
  
  ```php
  // Type could only be controlled through the NDArray constructor
  $x = new NDArray([1, 2, 3, 4], 'float32')->gpu();

  // NumPower::array() had no way to specify dtype
  $y = NumPower::array([1, 2, 3, 4]); // always float32 (implicit)
```
  ### After

```php
  $x = NumPower::array([1, 2, 3, 4]);               // float64 (default)
  $y = NumPower::array([1, 2, 3, 4], 'float32');    // float32
  $z = NumPower::array([1, 2, 3, 4], 'int32');      // int32
  $w = NumPower::array([1, 2, 3, 4], 'float64')->gpu(); // float64, on GPU
```
  ### Changes

  Supported $dtype values: float4, float8, float16, float32, float64, float128, int8, uint8, int16, uint16, int32, uint32, int64, uint64

  ### Notes
  
  - Default dtype changed from implicit float32 (via ZVAL_TO_NDARRAY) to explicit float64, consistent with NumPy's np.array() default and the task requirements.
  - When an NDArray object is passed as input, the dtype parameter is ignored and the existing object is returned as-is (no re-casting). Type conversion for existing arrays is out of scope for this change.
  - The implementation reuses NDArrayFactory_createFromZval, which already handles all input types (PHP arrays, scalars, GdImage) and manages buffer registration internally, avoiding double-add to the internal UUID buffer.