### PR TITLE
Math precision fixed

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -22,6 +22,20 @@ if test "$PHP_CUDA" != "no"; then
     ])
 fi
 
+PHP_CHECK_LIBRARY(quadmath, powq,
+[
+  AC_CHECK_HEADER([quadmath.h],
+  [
+    AC_DEFINE(HAVE_QUADMATH, 1, [Have libquadmath for full __float128 transcendental functions])
+    PHP_ADD_LIBRARY(quadmath,, NDARRAY_SHARED_LIBADD)
+    AC_MSG_RESULT([libquadmath detected: full float128 pow/fmod precision enabled])
+  ],[
+    AC_MSG_RESULT([libquadmath found but quadmath.h not in search path: float128 pow/fmod will use long double fallback])
+  ])
+],[
+  AC_MSG_RESULT([libquadmath not found: float128 pow/fmod will use long double fallback])
+])
+
 case $host_cpu in
     i?86|x86_64|amd64)
         AC_CHECK_HEADER([immintrin.h],

--- a/config.m4
+++ b/config.m4
@@ -28,6 +28,7 @@ PHP_CHECK_LIBRARY(quadmath, powq,
   [
     AC_DEFINE(HAVE_QUADMATH, 1, [Have libquadmath for full __float128 transcendental functions])
     PHP_ADD_LIBRARY(quadmath,, NDARRAY_SHARED_LIBADD)
+    CFLAGS+=" -lquadmath "
     AC_MSG_RESULT([libquadmath detected: full float128 pow/fmod precision enabled])
   ],[
     AC_MSG_RESULT([libquadmath found but quadmath.h not in search path: float128 pow/fmod will use long double fallback])

--- a/numpower.c
+++ b/numpower.c
@@ -441,22 +441,35 @@ static NDArray *ndarray_promote_and_op(zend_uchar opcode, NDArray *nda, NDArray 
 
     NDArray *a = nda_cast ? nda_cast : nda;
     NDArray *b = ndb_cast ? ndb_cast : ndb;
-    int use_double = is_type(comp_type, NDARRAY_TYPE_FLOAT64);
+    int use_double  = is_type(comp_type, NDARRAY_TYPE_FLOAT64);
+    int use_float128 = is_type(comp_type, NDARRAY_TYPE_FLOAT128);
 
     NDArray *rtn = NULL;
     switch (opcode) {
     case ZEND_ADD:
-        rtn = use_double ? NDArray_Add_Double(a, b)      : NDArray_Add_Float(a, b);      break;
+        rtn = use_float128 ? NDArray_Add_Float128(a, b)
+            : use_double   ? NDArray_Add_Double(a, b)
+                           : NDArray_Add_Float(a, b);      break;
     case ZEND_SUB:
-        rtn = use_double ? NDArray_Subtract_Double(a, b) : NDArray_Subtract_Float(a, b); break;
+        rtn = use_float128 ? NDArray_Subtract_Float128(a, b)
+            : use_double   ? NDArray_Subtract_Double(a, b)
+                           : NDArray_Subtract_Float(a, b); break;
     case ZEND_MUL:
-        rtn = use_double ? NDArray_Multiply_Double(a, b) : NDArray_Multiply_Float(a, b); break;
+        rtn = use_float128 ? NDArray_Multiply_Float128(a, b)
+            : use_double   ? NDArray_Multiply_Double(a, b)
+                           : NDArray_Multiply_Float(a, b); break;
     case ZEND_DIV:
-        rtn = use_double ? NDArray_Divide_Double(a, b)   : NDArray_Divide_Float(a, b);   break;
+        rtn = use_float128 ? NDArray_Divide_Float128(a, b)
+            : use_double   ? NDArray_Divide_Double(a, b)
+                           : NDArray_Divide_Float(a, b);   break;
     case ZEND_POW:
-        rtn = use_double ? NDArray_Pow_Double(a, b)      : NDArray_Pow_Float(a, b);      break;
+        rtn = use_float128 ? NDArray_Pow_Float128(a, b)
+            : use_double   ? NDArray_Pow_Double(a, b)
+                           : NDArray_Pow_Float(a, b);      break;
     case ZEND_MOD:
-        rtn = use_double ? NDArray_Mod_Double(a, b)      : NDArray_Mod_Float(a, b);      break;
+        rtn = use_float128 ? NDArray_Mod_Float128(a, b)
+            : use_double   ? NDArray_Mod_Double(a, b)
+                           : NDArray_Mod_Float(a, b);      break;
     default:
         break;
     }
@@ -740,10 +753,14 @@ PHP_METHOD(NDArray, toArray) {
         return;
     }
     if (NDArray_NDIM(array) == 0) {
-        if (NDArray_TYPE(array) == NDARRAY_TYPE_FLOAT32) {
+        if (is_type(NDArray_TYPE(array), NDARRAY_TYPE_FLOAT32)) {
             RETURN_DOUBLE(NDArray_F32DATA(array)[0]);
-        } else if (NDArray_TYPE(array) == NDARRAY_TYPE_FLOAT64) {
+        } else if (is_type(NDArray_TYPE(array), NDARRAY_TYPE_FLOAT64)) {
             RETURN_DOUBLE(NDArray_F64DATA(array)[0]);
+        } else if (is_type(NDArray_TYPE(array), NDARRAY_TYPE_FLOAT128)) {
+            char buf[64];
+            ndarray_fp128_to_string(NDArray_F128DATA(array)[0], buf, sizeof(buf));
+            RETURN_STRING(buf);
         }
         NDArray_FREE(array);
         return;

--- a/src/initializers.c
+++ b/src/initializers.c
@@ -861,6 +861,13 @@ NDArray* NDArray_FillDouble(NDArray *a, double fill_value) {
     return a;
 }
 
+NDArray* NDArray_FillFloat128(NDArray *a, ndarray_fp128_t fill_value) {
+    for (int i = 0; i < NDArray_NUMELEMENTS(a); i++) {
+        NDArray_F128DATA(a)[i] = fill_value;
+    }
+    return a;
+}
+
 /**
  * @param a
  * @return

--- a/src/initializers.h
+++ b/src/initializers.h
@@ -32,6 +32,7 @@ NDArray* NDArray_EmptyLike(NDArray *a);
 NDArray* NDArray_FromNDArrayBase(NDArray *target, char *data_ptr, int* shape, int* strides, const int ndim);
 
 NDArray* NDArray_FillDouble(NDArray *a, double fill_value);
+NDArray* NDArray_FillFloat128(NDArray *a, ndarray_fp128_t fill_value);
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/ndarray.c
+++ b/src/ndarray.c
@@ -1096,6 +1096,28 @@ convertStridedFLoat64ArrayToPHPArray(double *data, int *strides, int *dimensions
     return phpArray;
 }
 
+zval
+convertStridedFLoat128ArrayToPHPArray(ndarray_fp128_t *data, int *strides, int *dimensions, int ndim, int elsize) {
+    zval phpArray;
+    array_init_size(&phpArray, ndim);
+    for (int i = 0; i < dimensions[0]; i++) {
+        if (ndim > 1) {
+            zval subArray;
+            ndarray_fp128_t *subData = data + (i * (strides[0] / elsize));
+            int *subStrides     = strides + 1;
+            int *subDimensions  = dimensions + 1;
+            subArray = convertStridedFLoat128ArrayToPHPArray(subData, subStrides, subDimensions, ndim - 1, elsize);
+            add_index_zval(&phpArray, i, &subArray);
+        } else {
+            char buf[64];
+            ndarray_fp128_t val = *(data + (i * (*strides / elsize)));
+            ndarray_fp128_to_string(val, buf, sizeof(buf));
+            add_index_string(&phpArray, i, buf);
+        }
+    }
+    return phpArray;
+}
+
 #pragma clang diagnostic pop
 
 /**
@@ -1114,8 +1136,12 @@ NDArray_ToPHPArray(NDArray *target) {
         phpArray = convertStridedFLoat64ArrayToPHPArray(NDArray_F64DATA(target), NDArray_STRIDES(target),
                                                         NDArray_SHAPE(target), NDArray_NDIM(target),
                                                         NDArray_ELSIZE(target));
+    } else if (is_type(NDArray_TYPE(target), NDARRAY_TYPE_FLOAT128)) {
+        phpArray = convertStridedFLoat128ArrayToPHPArray(NDArray_F128DATA(target), NDArray_STRIDES(target),
+                                                         NDArray_SHAPE(target), NDArray_NDIM(target),
+                                                         NDArray_ELSIZE(target));
     } else {
-        /* For float16, float8, float4, float128, and integer types: convert to float64 for display */
+        /* For float16, float8, float4, and integer types: convert to float64 for display */
         NDArray *f64 = NDArray_AsType(target, NDARRAY_TYPE_FLOAT64);
         if (f64 == NULL) {
             array_init(&phpArray);

--- a/src/ndarray.h
+++ b/src/ndarray.h
@@ -8,6 +8,7 @@ extern "C" {
 #include "stddef.h"
 #include <Zend/zend_types.h>
 #include <stdbool.h>
+#include "ndarray_types.h"
 
 #define NDARRAY_MAX_DIMS 128
 #define NDARRAY_ARRAY_C_CONTIGUOUS    0x0001
@@ -18,6 +19,7 @@ extern "C" {
 #define NDArray_DESCRIPTOR(a) ((NDArrayDescriptor *)((a)->descriptor))
 #define NDArray_F64DATA(a) ((double *)((a)->data))
 #define NDArray_F32DATA(a) ((float *)((a)->data))
+#define NDArray_F128DATA(a) ((ndarray_fp128_t *)((a)->data))
 #define NDArray_NDIM(a) ((int)((a)->ndim))
 #define NDArray_FLAGS(a) ((int)((a)->flags))
 #define NDArray_SHAPE(a) ((int *)((a)->dimensions))

--- a/src/ndmath/arithmetics.c
+++ b/src/ndmath/arithmetics.c
@@ -2,6 +2,7 @@
 #include "Zend/zend_alloc.h"
 #include "Zend/zend_API.h"
 #include <string.h>
+#include <math.h>
 #include "arithmetics.h"
 #include "../../config.h"
 #include "../initializers.h"
@@ -9,6 +10,10 @@
 #include "../types.h"
 #include "../manipulation.h"
 #include "double_math.h"
+
+#if HAVE_QUADMATH && NDARRAY_HAVE_FLOAT128
+#  include <quadmath.h>
+#endif
 
 #ifdef HAVE_CUBLAS
 #include <cuda_runtime.h>
@@ -1599,5 +1604,193 @@ NDArray_Mod_Double(NDArray *a, NDArray *b)
     if (a_temp != NULL) NDArray_FREE(a);
     if (b_temp != NULL) NDArray_FREE(b);
     if (broadcasted != NULL) NDArray_FREE(broadcasted);
+    return result;
+}
+
+/* ── float128 element-wise arithmetic helpers ─────────────────────────────── */
+
+static NDArray *alloc_fp128_result(NDArray *a_broad) {
+    NDArray *result = (NDArray *) emalloc(sizeof(NDArray));
+    result->strides    = (int *) emalloc(a_broad->ndim * sizeof(int));
+    result->dimensions = (int *) emalloc(a_broad->ndim * sizeof(int));
+    result->ndim       = a_broad->ndim;
+    result->data       = (char *) emalloc(a_broad->descriptor->numElements * NDARRAY_FP128_SIZE);
+    result->base       = NULL;
+    result->flags      = 0;
+    result->device     = NDARRAY_DEVICE_CPU;
+    result->descriptor = (NDArrayDescriptor *) emalloc(sizeof(NDArrayDescriptor));
+    result->descriptor->type        = NDARRAY_TYPE_FLOAT128;
+    result->descriptor->elsize      = NDARRAY_FP128_SIZE;
+    result->descriptor->numElements = a_broad->descriptor->numElements;
+    result->refcount   = 1;
+    memcpy(result->strides,    a_broad->strides,    a_broad->ndim * sizeof(int));
+    memcpy(result->dimensions, a_broad->dimensions, a_broad->ndim * sizeof(int));
+    NDArrayIterator_INIT(result);
+    return result;
+}
+
+static NDArray *fp128_broadcast_scalar(NDArray *scalar, NDArray *other) {
+    int *n_shape = emalloc(sizeof(int) * NDArray_NDIM(other));
+    copy(NDArray_SHAPE(other), n_shape, NDArray_NDIM(other));
+    NDArray *expanded = NDArray_Zeros(n_shape, NDArray_NDIM(other),
+                                     NDARRAY_TYPE_FLOAT128, NDARRAY_DEVICE_CPU);
+    ndarray_fp128_t val;
+    memcpy(&val, scalar->data, NDARRAY_FP128_SIZE);
+    return NDArray_FillFloat128(expanded, val);
+}
+
+NDArray* NDArray_Add_Float128(NDArray* a, NDArray* b) {
+    NDArray *a_temp = NULL, *b_temp = NULL;
+    if (NDArray_NDIM(a) == 0 && NDArray_NDIM(b) > 0) {
+        a_temp = a; a = fp128_broadcast_scalar(a, b);
+    } else if (NDArray_NDIM(b) == 0 && NDArray_NDIM(a) > 0) {
+        b_temp = b; b = fp128_broadcast_scalar(b, a);
+    }
+    NDArray *broadcasted = NULL, *a_broad, *b_broad;
+    if (NDArray_NUMELEMENTS(a) < NDArray_NUMELEMENTS(b)) {
+        broadcasted = NDArray_Broadcast(a, b); a_broad = broadcasted; b_broad = b;
+    } else if (NDArray_NUMELEMENTS(b) < NDArray_NUMELEMENTS(a)) {
+        broadcasted = NDArray_Broadcast(b, a); b_broad = broadcasted; a_broad = a;
+    } else { a_broad = a; b_broad = b; }
+    NDArray *result = alloc_fp128_result(a_broad);
+    ndarray_fp128_t *rd = NDArray_F128DATA(result);
+    ndarray_fp128_t *ad = NDArray_F128DATA(a_broad);
+    ndarray_fp128_t *bd = NDArray_F128DATA(b_broad);
+    for (int i = 0; i < result->descriptor->numElements; i++) rd[i] = ad[i] + bd[i];
+    if (a_temp) NDArray_FREE(a);
+    if (b_temp) NDArray_FREE(b);
+    if (broadcasted) NDArray_FREE(broadcasted);
+    return result;
+}
+
+NDArray* NDArray_Subtract_Float128(NDArray* a, NDArray* b) {
+    NDArray *a_temp = NULL, *b_temp = NULL;
+    if (NDArray_NDIM(a) == 0 && NDArray_NDIM(b) > 0) {
+        a_temp = a; a = fp128_broadcast_scalar(a, b);
+    } else if (NDArray_NDIM(b) == 0 && NDArray_NDIM(a) > 0) {
+        b_temp = b; b = fp128_broadcast_scalar(b, a);
+    }
+    NDArray *broadcasted = NULL, *a_broad, *b_broad;
+    if (NDArray_NUMELEMENTS(a) < NDArray_NUMELEMENTS(b)) {
+        broadcasted = NDArray_Broadcast(a, b); a_broad = broadcasted; b_broad = b;
+    } else if (NDArray_NUMELEMENTS(b) < NDArray_NUMELEMENTS(a)) {
+        broadcasted = NDArray_Broadcast(b, a); b_broad = broadcasted; a_broad = a;
+    } else { a_broad = a; b_broad = b; }
+    NDArray *result = alloc_fp128_result(a_broad);
+    ndarray_fp128_t *rd = NDArray_F128DATA(result);
+    ndarray_fp128_t *ad = NDArray_F128DATA(a_broad);
+    ndarray_fp128_t *bd = NDArray_F128DATA(b_broad);
+    for (int i = 0; i < result->descriptor->numElements; i++) rd[i] = ad[i] - bd[i];
+    if (a_temp) NDArray_FREE(a);
+    if (b_temp) NDArray_FREE(b);
+    if (broadcasted) NDArray_FREE(broadcasted);
+    return result;
+}
+
+NDArray* NDArray_Multiply_Float128(NDArray* a, NDArray* b) {
+    NDArray *a_temp = NULL, *b_temp = NULL;
+    if (NDArray_NDIM(a) == 0 && NDArray_NDIM(b) > 0) {
+        a_temp = a; a = fp128_broadcast_scalar(a, b);
+    } else if (NDArray_NDIM(b) == 0 && NDArray_NDIM(a) > 0) {
+        b_temp = b; b = fp128_broadcast_scalar(b, a);
+    }
+    NDArray *broadcasted = NULL, *a_broad, *b_broad;
+    if (NDArray_NUMELEMENTS(a) < NDArray_NUMELEMENTS(b)) {
+        broadcasted = NDArray_Broadcast(a, b); a_broad = broadcasted; b_broad = b;
+    } else if (NDArray_NUMELEMENTS(b) < NDArray_NUMELEMENTS(a)) {
+        broadcasted = NDArray_Broadcast(b, a); b_broad = broadcasted; a_broad = a;
+    } else { a_broad = a; b_broad = b; }
+    NDArray *result = alloc_fp128_result(a_broad);
+    ndarray_fp128_t *rd = NDArray_F128DATA(result);
+    ndarray_fp128_t *ad = NDArray_F128DATA(a_broad);
+    ndarray_fp128_t *bd = NDArray_F128DATA(b_broad);
+    for (int i = 0; i < result->descriptor->numElements; i++) rd[i] = ad[i] * bd[i];
+    if (a_temp) NDArray_FREE(a);
+    if (b_temp) NDArray_FREE(b);
+    if (broadcasted) NDArray_FREE(broadcasted);
+    return result;
+}
+
+NDArray* NDArray_Divide_Float128(NDArray* a, NDArray* b) {
+    NDArray *a_temp = NULL, *b_temp = NULL;
+    if (NDArray_NDIM(a) == 0 && NDArray_NDIM(b) > 0) {
+        a_temp = a; a = fp128_broadcast_scalar(a, b);
+    } else if (NDArray_NDIM(b) == 0 && NDArray_NDIM(a) > 0) {
+        b_temp = b; b = fp128_broadcast_scalar(b, a);
+    }
+    NDArray *broadcasted = NULL, *a_broad, *b_broad;
+    if (NDArray_NUMELEMENTS(a) < NDArray_NUMELEMENTS(b)) {
+        broadcasted = NDArray_Broadcast(a, b); a_broad = broadcasted; b_broad = b;
+    } else if (NDArray_NUMELEMENTS(b) < NDArray_NUMELEMENTS(a)) {
+        broadcasted = NDArray_Broadcast(b, a); b_broad = broadcasted; a_broad = a;
+    } else { a_broad = a; b_broad = b; }
+    NDArray *result = alloc_fp128_result(a_broad);
+    ndarray_fp128_t *rd = NDArray_F128DATA(result);
+    ndarray_fp128_t *ad = NDArray_F128DATA(a_broad);
+    ndarray_fp128_t *bd = NDArray_F128DATA(b_broad);
+    for (int i = 0; i < result->descriptor->numElements; i++) rd[i] = ad[i] / bd[i];
+    if (a_temp) NDArray_FREE(a);
+    if (b_temp) NDArray_FREE(b);
+    if (broadcasted) NDArray_FREE(broadcasted);
+    return result;
+}
+
+NDArray* NDArray_Mod_Float128(NDArray* a, NDArray* b) {
+    NDArray *a_temp = NULL, *b_temp = NULL;
+    if (NDArray_NDIM(a) == 0 && NDArray_NDIM(b) > 0) {
+        a_temp = a; a = fp128_broadcast_scalar(a, b);
+    } else if (NDArray_NDIM(b) == 0 && NDArray_NDIM(a) > 0) {
+        b_temp = b; b = fp128_broadcast_scalar(b, a);
+    }
+    NDArray *broadcasted = NULL, *a_broad, *b_broad;
+    if (NDArray_NUMELEMENTS(a) < NDArray_NUMELEMENTS(b)) {
+        broadcasted = NDArray_Broadcast(a, b); a_broad = broadcasted; b_broad = b;
+    } else if (NDArray_NUMELEMENTS(b) < NDArray_NUMELEMENTS(a)) {
+        broadcasted = NDArray_Broadcast(b, a); b_broad = broadcasted; a_broad = a;
+    } else { a_broad = a; b_broad = b; }
+    NDArray *result = alloc_fp128_result(a_broad);
+    ndarray_fp128_t *rd = NDArray_F128DATA(result);
+    ndarray_fp128_t *ad = NDArray_F128DATA(a_broad);
+    ndarray_fp128_t *bd = NDArray_F128DATA(b_broad);
+    for (int i = 0; i < result->descriptor->numElements; i++) {
+#if HAVE_QUADMATH && NDARRAY_HAVE_FLOAT128
+        rd[i] = fmodq(ad[i], bd[i]);
+#else
+        rd[i] = (ndarray_fp128_t)fmodl((long double)ad[i], (long double)bd[i]);
+#endif
+    }
+    if (a_temp) NDArray_FREE(a);
+    if (b_temp) NDArray_FREE(b);
+    if (broadcasted) NDArray_FREE(broadcasted);
+    return result;
+}
+
+NDArray* NDArray_Pow_Float128(NDArray* a, NDArray* b) {
+    NDArray *a_temp = NULL, *b_temp = NULL;
+    if (NDArray_NDIM(a) == 0 && NDArray_NDIM(b) > 0) {
+        a_temp = a; a = fp128_broadcast_scalar(a, b);
+    } else if (NDArray_NDIM(b) == 0 && NDArray_NDIM(a) > 0) {
+        b_temp = b; b = fp128_broadcast_scalar(b, a);
+    }
+    NDArray *broadcasted = NULL, *a_broad, *b_broad;
+    if (NDArray_NUMELEMENTS(a) < NDArray_NUMELEMENTS(b)) {
+        broadcasted = NDArray_Broadcast(a, b); a_broad = broadcasted; b_broad = b;
+    } else if (NDArray_NUMELEMENTS(b) < NDArray_NUMELEMENTS(a)) {
+        broadcasted = NDArray_Broadcast(b, a); b_broad = broadcasted; a_broad = a;
+    } else { a_broad = a; b_broad = b; }
+    NDArray *result = alloc_fp128_result(a_broad);
+    ndarray_fp128_t *rd = NDArray_F128DATA(result);
+    ndarray_fp128_t *ad = NDArray_F128DATA(a_broad);
+    ndarray_fp128_t *bd = NDArray_F128DATA(b_broad);
+    for (int i = 0; i < result->descriptor->numElements; i++) {
+#if HAVE_QUADMATH && NDARRAY_HAVE_FLOAT128
+        rd[i] = powq(ad[i], bd[i]);
+#else
+        rd[i] = (ndarray_fp128_t)powl((long double)ad[i], (long double)bd[i]);
+#endif
+    }
+    if (a_temp) NDArray_FREE(a);
+    if (b_temp) NDArray_FREE(b);
+    if (broadcasted) NDArray_FREE(broadcasted);
     return result;
 }

--- a/src/ndmath/arithmetics.h
+++ b/src/ndmath/arithmetics.h
@@ -26,6 +26,14 @@ NDArray* NDArray_Divide_Double(NDArray* a, NDArray* b);
 NDArray* NDArray_Mod_Double(NDArray* a, NDArray* b);
 double NDArray_Sum_Double(NDArray* a);
 
+//Float128
+NDArray* NDArray_Add_Float128(NDArray* a, NDArray* b);
+NDArray* NDArray_Subtract_Float128(NDArray* a, NDArray* b);
+NDArray* NDArray_Multiply_Float128(NDArray* a, NDArray* b);
+NDArray* NDArray_Divide_Float128(NDArray* a, NDArray* b);
+NDArray* NDArray_Pow_Float128(NDArray* a, NDArray* b);
+NDArray* NDArray_Mod_Float128(NDArray* a, NDArray* b);
+
 NDArray* NDArray_Add(NDArray* a, NDArray* b);
 
 #endif //PHPSCI_NDARRAY_ARITHMETICS_H

--- a/tests/math/050-ndarray-float128-arithmetic.phpt
+++ b/tests/math/050-ndarray-float128-arithmetic.phpt
@@ -1,0 +1,39 @@
+--TEST--
+float128 arithmetic: result dtype, precision, and toArray returns strings
+--FILE--
+<?php
+$b = NumPower::array([['1.01234567890321654987', 2],[3, 3]], 'float128');
+$c = NumPower::array([['0.123456789987654321', 2],[3, 3]], 'float128');
+
+// Addition
+$x = $b + $c;
+$arr = $x->toArray();
+echo $arr[0][0] . "\n";
+echo $arr[0][1] . "\n";
+echo $arr[1][0] . "\n";
+echo $arr[1][1] . "\n";
+
+// toArray returns strings for float128 (PHP float cannot represent full precision)
+var_dump(gettype($arr[0][0]) === 'string');
+
+// Subtraction: 2 - 2 = 0
+$s = $b - $c;
+echo $s->toArray()[0][1] . "\n";
+
+// Multiplication: 2 * 2 = 4
+$m = $b * $c;
+echo $m->toArray()[0][1] . "\n";
+
+// Division: 2 / 2 = 1
+$d = $b / $c;
+echo $d->toArray()[0][1] . "\n";
+?>
+--EXPECT--
+1.13580246889087087
+4
+6
+6
+bool(true)
+0
+4
+1

--- a/tests/math/051-ndarray-float128-pow-mod.phpt
+++ b/tests/math/051-ndarray-float128-pow-mod.phpt
@@ -1,0 +1,25 @@
+--TEST--
+float128 pow and mod: use quadmath (powq/fmodq) when available, else long double fallback
+--FILE--
+<?php
+$two   = NumPower::array(['2'], 'float128');
+$three = NumPower::array(['3'], 'float128');
+$seven = NumPower::array(['7'], 'float128');
+
+// 2 ** 3 = 8
+$p = NumPower::pow($two, $three);
+echo $p->toArray()[0] . "\n";
+
+// 7 % 3 = 1
+$m = NumPower::mod($seven, $three);
+echo $m->toArray()[0] . "\n";
+
+// Result type must be float128 (toArray returns strings)
+var_dump(gettype($p->toArray()[0]) === 'string');
+var_dump(gettype($m->toArray()[0]) === 'string');
+?>
+--EXPECT--
+8
+1
+bool(true)
+bool(true)

--- a/tests/types/015-dtype-float128-toarray.phpt
+++ b/tests/types/015-dtype-float128-toarray.phpt
@@ -1,0 +1,20 @@
+--TEST--
+NDArray float128 dtype: toArray returns strings preserving precision
+--FILE--
+<?php
+$a = new NDArray(["1.23456789012345678901234", "3.14159265358979323846264338327950288"], "float128");
+$arr = $a->toArray();
+
+// Elements must be strings (PHP float/double cannot represent float128 precision)
+var_dump(gettype($arr[0]) === 'string');
+var_dump(gettype($arr[1]) === 'string');
+
+// Values should preserve at least 18 significant digits
+echo $arr[0] . "\n";
+echo $arr[1] . "\n";
+?>
+--EXPECT--
+bool(true)
+bool(true)
+1.23456789012345679
+3.14159265358979324


### PR DESCRIPTION
# Fix: float128 arithmetic dtype, precision, and toArray string output

## Summary

Fixes three bugs that caused float128 arrays to produce incorrect results during
arithmetic operations, and adds `libquadmath` as an optional dependency for full
128-bit precision in `pow` and `fmod`.

---

## Bugs fixed

### 1. Wrong result dtype (float128 → float32)

**Root cause** — `ndarray_promote_and_op` in `numpower.c` dispatched operations
based on a single `use_double` flag that only checked for `float64`. Operations on
`float128` arrays fell through to `NDArray_Add_Float` / `NDArray_Subtract_Float`
etc., which allocate a `float32` result buffer and set `descriptor->type =
NDARRAY_TYPE_FLOAT32`.

**Fix** — added a second dispatch level `use_float128 = is_type(comp_type,
NDARRAY_TYPE_FLOAT128)` and a new set of `NDArray_*_Float128` functions that
allocate 16-byte-per-element buffers and set `descriptor->type =
NDARRAY_TYPE_FLOAT128`.

### 2. Corrupted element values

**Root cause** — consequence of bug #1: 16-byte `__float128` values were passed to
`float32` functions that read 4 bytes per element, producing garbage.

**Fix** — resolved automatically by bug #1 fix.

### 3. `toArray()` returned PHP `float` instead of `string` for float128

**Root cause** — `NDArray_ToPHPArray` in `src/ndarray.c` had no branch for
`float128`; it fell into the else-case that cast elements to `float64` before
building the PHP array. PHP's native `float` (IEEE-754 double) holds only ~15–17
significant digits, which is less than the ~34 digits of `__float128`.

**Fix** — added `convertStridedFLoat128ArrayToPHPArray` that converts each element
to a string via `ndarray_fp128_to_string`, and wired it into `NDArray_ToPHPArray`.
The scalar path in `NDArray::toArray()` likewise now returns a `string` for
`float128` scalars.

---

## Optional libquadmath dependency

`pow` and `fmod` for `__float128` require transcendental functions not provided by
the standard C library. Two precision levels are now supported:

| Build | `pow` / `fmod` precision | Requires |
|-------|--------------------------|----------|
| with `libquadmath` | Full 128-bit (`powq` / `fmodq`) | `libquadmath-dev` |
| without `libquadmath` | 80-bit `long double` (`powl` / `fmodl`) | nothing extra |

Basic arithmetic (`+`, `−`, `×`, `÷`) always uses the native GCC `__float128`
operators and does not depend on `libquadmath`.